### PR TITLE
Correct incorrect variable substitution in hive-0.8.1 jobtype properties

### DIFF
--- a/plugins/jobtype/jobtypes/hive-0.8.1/private.properties
+++ b/plugins/jobtype/jobtypes/hive-0.8.1/private.properties
@@ -1,4 +1,4 @@
-jobtype.classpath=${hadoop.home}/conf,${hadoop.home}/lib/*,${hive.home}/lib/*,${hive.home}/conf,${hive.aux.jar.path}
+jobtype.classpath=${hadoop.home}/conf,${hadoop.home}/lib/*,${hive.home}/lib/*,${hive.home}/conf,${hive.aux.jars.path}
 jobtype.class=azkaban.jobtype.HadoopJavaJob
 
 hive.aux.jars.path=${hive.home}/aux/lib


### PR DESCRIPTION
${hive.aux.jar.path} should be ${hive.aux.jars.path}, otherwise you get an exception due to the variable substitution not being found.
