### PR TITLE
Use PST instead of UTC for Reportal time variables (hive_last_hour, etc.)

### DIFF
--- a/plugins/reportal/conf/jobtypes/common.properties
+++ b/plugins/reportal/conf/jobtypes/common.properties
@@ -5,4 +5,4 @@ reportal.output.location=/tmp/reportal
 azkaban.should.proxy=true
 reportal.execution.user=azkaban
 reportal.storage.user=reportal
-reportal.time.variable.timezone=America/Los_Angeles
+reportal.default.timezone=America/Los_Angeles

--- a/plugins/reportal/src/azkaban/jobtype/ReportalAbstractRunner.java
+++ b/plugins/reportal/src/azkaban/jobtype/ReportalAbstractRunner.java
@@ -100,7 +100,7 @@ public abstract class ReportalAbstractRunner {
 		Date date = new Date();
 		cal.setTime(date);
 		
-		String timeZone = props.getString("reportal.time.variable.timezone", "UTC");
+		String timeZone = props.getString("reportal.default.timezone", "UTC");
 		TimeZone.setDefault(TimeZone.getTimeZone(timeZone));
 		
 		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");


### PR DESCRIPTION
This is important because our Hive date partitions use PST.
