### PR TITLE
Escape HTML in Reportal results

### DIFF
--- a/plugins/reportal/src/azkaban/viewer/reportal/ReportalMailCreator.java
+++ b/plugins/reportal/src/azkaban/viewer/reportal/ReportalMailCreator.java
@@ -33,6 +33,7 @@ import java.util.Scanner;
 import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutableNode;
@@ -245,7 +246,8 @@ public class ReportalMailCreator implements MailCreator {
 						String[] data = csvLine.split("\",\"");
 						message.println("<tr>");
 						for (String item : data) {
-							message.println("<td>" + item.replace("\"", "") + "</td>");
+						  String column = StringEscapeUtils.escapeHtml(item.replace("\"", ""));
+						  message.println("<td>" + column + "</td>");
 						}
 						message.println("</tr>");
 						if (lineNumber == NUM_PREVIEW_ROWS && rowScanner.hasNextLine()) {

--- a/plugins/reportal/src/azkaban/viewer/reportal/ReportalServlet.java
+++ b/plugins/reportal/src/azkaban/viewer/reportal/ReportalServlet.java
@@ -36,6 +36,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.log4j.Logger;
 import org.apache.velocity.tools.generic.EscapeTool;
@@ -430,7 +431,8 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
 							String[] data = csvLine.split("\",\"");
 							ArrayList<String> line = new ArrayList<String>();
 							for (String item: data) {
-								line.add(item.replace("\"", ""));
+							  String column = StringEscapeUtils.escapeHtml(item.replace("\"", ""));
+							  line.add(column);
 							}
 							lines.add(line);
 							lineNumber++;


### PR DESCRIPTION
Escapes HTML in Reportal results, so that they render properly in the preview tables.

Tracked by internal JIRA ticket: HADOOP-4398.
