### PR TITLE
Add .travis.yml and Travis CI build image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+languages: java
+install:
+ - time npm install -g less dustjs-linkedin
+script: ant

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Azkaban Plugins
 
+[![Build Status](https://travis-ci.org/azkaban/azkaban-plugins.png?branch=master)](https://travis-ci.org/azkaban/azkaban-plugins)
+
 For all Azkaban Plugins documentation, please go to 
 [Azkaban Project Site](http://azkaban.github.io/azkaban2/)
 


### PR DESCRIPTION
- I have already enabled the azkaban/azkaban-plugins repository in Travis.
- These changes add the .travis.yml and build image to the README.
- These changes depend on #47, which provides the root Ant build.xml.
