### PR TITLE
Copy jobtype and hadoopsecuritymanager jars to directory for new hive job type

### DIFF
--- a/plugins/jobtype/build.xml
+++ b/plugins/jobtype/build.xml
@@ -107,6 +107,7 @@
 		<copy file="${azkaban-jobtype-jar}" todir="${dist.packages.dir}/pig-0.11.0" />
 		<copy file="${azkaban-jobtype-jar}" todir="${dist.packages.dir}/pig-0.12.0" />
 		<copy file="${azkaban-jobtype-jar}" todir="${dist.packages.dir}/hive-0.8.1" />
+		<copy file="${azkaban-jobtype-jar}" todir="${dist.packages.dir}/hive" />
 
 		<!-- Copy hadoopsecuritymanager-->
 		<copy file="${hadoopsecuritymanagerjar}" todir="${dist.packages.dir}/java" />
@@ -117,6 +118,7 @@
 		<copy file="${hadoopsecuritymanagerjar}" todir="${dist.packages.dir}/pig-0.11.0" />
 		<copy file="${hadoopsecuritymanagerjar}" todir="${dist.packages.dir}/pig-0.12.0" />
 		<copy file="${hadoopsecuritymanagerjar}" todir="${dist.packages.dir}/hive-0.8.1" />
+		<copy file="${hadoopsecuritymanagerjar}" todir="${dist.packages.dir}/hive" />
 		
 		<!-- Tarball it -->
 		<tar destfile="${dist.packages.dir}/${name}-${version}.tar.gz" compression="gzip" longfile="gnu">


### PR DESCRIPTION
Fixes #66
