### PR TITLE
Fix for issue #84: Reportal: Users should be able to specify whether they want their results rendered as HTML or not

### DIFF
--- a/plugins/reportal/src/azkaban/reportal/util/Reportal.java
+++ b/plugins/reportal/src/azkaban/reportal/util/Reportal.java
@@ -72,6 +72,8 @@ public class Reportal {
 	public String scheduleIntervalQuantity;
 	public String scheduleInterval;
 
+	public boolean renderResultsAsHtml;
+
 	public String accessViewer;
 	public String accessExecutor;
 	public String accessOwner;
@@ -99,6 +101,8 @@ public class Reportal {
 		project.getMetadata().put("scheduleRepeat", scheduleRepeat);
 		project.getMetadata().put("scheduleIntervalQuantity", scheduleIntervalQuantity);
 		project.getMetadata().put("scheduleInterval", scheduleInterval);
+
+		project.getMetadata().put("renderResultsAsHtml", renderResultsAsHtml);
 
 		project.getMetadata().put("accessViewer", accessViewer);
 		project.getMetadata().put("accessExecutor", accessExecutor);
@@ -170,8 +174,10 @@ public class Reportal {
 			
 			ExecutionOptions options = new ExecutionOptions();
 			options.getFlowParameters().put("reportal.execution.user", user.getUserId());
-			options.setMailCreator(ReportalMailCreator.REPORTAL_MAIL_CREATOR);
 			options.getFlowParameters().put("reportal.title", report.title);
+			options.getFlowParameters().put("reportal.render.results.as.html",
+			                                report.renderResultsAsHtml ? "true" : "false");
+			options.setMailCreator(ReportalMailCreator.REPORTAL_MAIL_CREATOR);
 
 			scheduleManager.scheduleFlow(-1, project.getId(), project.getName(), flow.getId(), "ready",
 					firstSchedTime.getMillis(), firstSchedTime.getZone(), period, DateTime.now().getMillis(),
@@ -331,6 +337,8 @@ public class Reportal {
 		reportal.scheduleRepeat = boolGetter.get(project.getMetadata().get("scheduleRepeat"));
 		reportal.scheduleIntervalQuantity = stringGetter.get(project.getMetadata().get("scheduleIntervalQuantity"));
 		reportal.scheduleInterval = stringGetter.get(project.getMetadata().get("scheduleInterval"));
+
+		reportal.renderResultsAsHtml = boolGetter.get(project.getMetadata().get("renderResultsAsHtml"));
 
 		reportal.accessViewer = stringGetter.get(project.getMetadata().get("accessViewer"));
 		reportal.accessExecutor = stringGetter.get(project.getMetadata().get("accessExecutor"));

--- a/plugins/reportal/src/azkaban/viewer/reportal/ReportalMailCreator.java
+++ b/plugins/reportal/src/azkaban/viewer/reportal/ReportalMailCreator.java
@@ -219,6 +219,10 @@ public class ReportalMailCreator implements MailCreator {
 			
 			boolean emptyResults = true;
 
+			String htmlResults = flowParameters.get("reportal.render.results.as.html");
+			boolean renderResultsAsHtml = htmlResults != null
+			    && htmlResults.trim().equalsIgnoreCase("true");
+
 			for (i = 0; i < fileList.length; i++) {
 			  String file = fileList[i];
 			  ExecutableNode job = jobs.get(i);
@@ -246,7 +250,10 @@ public class ReportalMailCreator implements MailCreator {
 						String[] data = csvLine.split("\",\"");
 						message.println("<tr>");
 						for (String item : data) {
-						  String column = StringEscapeUtils.escapeHtml(item.replace("\"", ""));
+						  String column = item.replace("\"", "");
+						  if (!renderResultsAsHtml) {
+						    column = StringEscapeUtils.escapeHtml(column);
+						  }
 						  message.println("<td>" + column + "</td>");
 						}
 						message.println("</tr>");

--- a/plugins/reportal/src/azkaban/viewer/reportal/ReportalServlet.java
+++ b/plugins/reportal/src/azkaban/viewer/reportal/ReportalServlet.java
@@ -444,7 +444,8 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
 							fileList = ReportalHelper.filterCSVFile(fileList);
 							Arrays.sort(fileList);
 							
-							List<Object> files = getFilePreviews(fileList, locationFull, streamProvider);
+							List<Object> files = getFilePreviews(fileList, locationFull, streamProvider,
+							                                     reportal.renderResultsAsHtml);
 							
 							page.add("files", files);
 						} catch (Exception e) {
@@ -518,7 +519,9 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
 	 * @param streamProvider
 	 * @return
 	 */
-	private List<Object> getFilePreviews(String[] fileList, String locationFull, IStreamProvider streamProvider) {
+	private List<Object> getFilePreviews(String[] fileList, String locationFull,
+	                                     IStreamProvider streamProvider,
+	                                     boolean renderResultsAsHtml) {
 		List<Object> files = new ArrayList<Object>();
 		InputStream csvInputStream = null;
 		
@@ -538,7 +541,10 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
 					String[] data = csvLine.split("\",\"");
 					List<String> line = new ArrayList<String>();
 					for (String item: data) {
-					  String column = StringEscapeUtils.escapeHtml(item.replace("\"", ""));
+					  String column = item.replace("\"", "");
+					  if (!renderResultsAsHtml) {
+					    column = StringEscapeUtils.escapeHtml(column);
+					  }
 					  line.add(column);
 					}
 					lines.add(line);
@@ -668,6 +674,7 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
 		page.add("scheduleRepeat", reportal.scheduleRepeat);
 		page.add("scheduleIntervalQuantity", reportal.scheduleIntervalQuantity);
 		page.add("scheduleInterval", reportal.scheduleInterval);
+		page.add("renderResultsAsHtml", reportal.renderResultsAsHtml);
 		page.add("notifications", reportal.notifications);
 		page.add("failureNotifications", reportal.failureNotifications);
 		page.add("accessViewer", reportal.accessViewer);
@@ -749,6 +756,7 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
 		report.scheduleRepeat = hasParam(req, "schedule-repeat");
 		report.scheduleIntervalQuantity = getParam(req, "schedule-interval-quantity");
 		report.scheduleInterval = getParam(req, "schedule-interval");
+		report.renderResultsAsHtml = hasParam(req, "render-results-as-html");
 		page.add("schedule", report.schedule);
 		page.add("scheduleHour", report.scheduleHour);
 		page.add("scheduleMinute", report.scheduleMinute);
@@ -758,6 +766,7 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
 		page.add("scheduleRepeat", report.scheduleRepeat);
 		page.add("scheduleIntervalQuantity", report.scheduleIntervalQuantity);
 		page.add("scheduleInterval", report.scheduleInterval);
+		page.add("renderResultsAsHtml", report.renderResultsAsHtml);
 
 		report.accessViewer = getParam(req, "access-viewer");
 		report.accessExecutor = getParam(req, "access-executor");
@@ -1091,7 +1100,8 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
 		}
 		
 		options.getFlowParameters().put("reportal.title", report.title);
-		
+		options.getFlowParameters().put("reportal.render.results.as.html",
+		                                report.renderResultsAsHtml ? "true" : "false");
 		options.getFlowParameters().put("reportal.unscheduled.run", "true");
 
 		try {

--- a/plugins/reportal/src/azkaban/viewer/reportal/reportaleditpage.vm
+++ b/plugins/reportal/src/azkaban/viewer/reportal/reportaleditpage.vm
@@ -130,6 +130,13 @@
 						<div class="control-group">
 							<div class="controls">
 								<label class="checkbox">
+									<input name="render-results-as-html" type="checkbox"#if($renderResultsAsHtml) checked#end />Render results as HTML
+								</label>
+							</div>
+						</div>
+						<div class="control-group">
+							<div class="controls">
+								<label class="checkbox">
 									<input id="schedule-options" name="schedule" type="checkbox"#if($schedule) checked#end />Schedule
 								</label>
 							</div>


### PR DESCRIPTION
Added a "Render results as HTML" checkbox to the report edit page.
