### PR TITLE
Prevent reports from running concurrently

### DIFF
--- a/plugins/jobtype/src/azkaban/jobtype/HadoopConfigurationInjector.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopConfigurationInjector.java
@@ -19,12 +19,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Properties;
-
-import org.apache.log4j.Logger;
 
 import org.apache.hadoop.conf.Configuration;
-import azkaban.flow.CommonJobProperties;
+
 import azkaban.utils.Props;
 
 /**

--- a/plugins/reportal/src/azkaban/reportal/util/Reportal.java
+++ b/plugins/reportal/src/azkaban/reportal/util/Reportal.java
@@ -181,6 +181,8 @@ public class Reportal {
       }
 
       ExecutionOptions options = new ExecutionOptions();
+      // don't run flow concurrently
+      options.setConcurrentOption(ExecutionOptions.CONCURRENT_OPTION_SKIP);
       options.getFlowParameters().put("reportal.execution.user",
           user.getUserId());
       options.getFlowParameters().put("reportal.title", report.title);

--- a/plugins/reportal/src/azkaban/viewer/reportal/ReportalServlet.java
+++ b/plugins/reportal/src/azkaban/viewer/reportal/ReportalServlet.java
@@ -543,7 +543,7 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
    * Returns a list of file Objects that contain a "name" property with the file
    * name, a "content" property with the lines in the file, and a "hasMore"
    * property if the file contains more than NUM_PREVIEW_ROWS lines.
-   *
+   * 
    * @param fileList
    * @param locationFull
    * @param streamProvider
@@ -764,7 +764,7 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
   /**
    * Validates and saves a report, returning the project id of the saved report
    * if successful, and null otherwise.
-   *
+   * 
    * @param req
    * @param resp
    * @param session
@@ -1143,6 +1143,9 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
     exflow.addAllProxyUsers(project.getProxyUsers());
 
     ExecutionOptions options = exflow.getExecutionOptions();
+
+    // don't run flow concurrently
+    options.setConcurrentOption(ExecutionOptions.CONCURRENT_OPTION_SKIP);
 
     int i = 0;
     for (Variable variable : report.variables) {


### PR DESCRIPTION
Fixes #112

The ExecutionOptions.CONCURRENT_OPTION_SKIP is set whenever a report is updated or user run a report.
