### PR TITLE
Removed dependency on removed interface method in ReportalHiveRunner

### DIFF
--- a/plugins/reportal/src/azkaban/jobtype/ReportalHiveRunner.java
+++ b/plugins/reportal/src/azkaban/jobtype/ReportalHiveRunner.java
@@ -102,22 +102,19 @@ public class ReportalHiveRunner extends ReportalAbstractRunner {
       HiveConf.setVar(conf, HiveConf.ConfVars.HIVEAUXJARS, expanded);
     }
 
-    if (!ShimLoader.getHadoopShims().usesJobShell()) {
-      // hadoop-20 and above - we need to augment classpath using hiveconf
-      // components
-      // see also: code in ExecDriver.java
-      ClassLoader loader = conf.getClassLoader();
-      String auxJars = HiveConf.getVar(conf, HiveConf.ConfVars.HIVEAUXJARS);
+    // hadoop-20 and above - we need to augment classpath using hiveconf
+    // components
+    // see also: code in ExecDriver.java
+    ClassLoader loader = conf.getClassLoader();
+    String auxJars = HiveConf.getVar(conf, HiveConf.ConfVars.HIVEAUXJARS);
 
-      System.out.println("Got auxJars = " + auxJars);
+    System.out.println("Got auxJars = " + auxJars);
 
-      if (StringUtils.isNotBlank(auxJars)) {
-        loader =
-            Utilities.addToClassPath(loader, StringUtils.split(auxJars, ","));
-      }
-      conf.setClassLoader(loader);
-      Thread.currentThread().setContextClassLoader(loader);
+    if (StringUtils.isNotBlank(auxJars)) {
+      loader = Utilities.addToClassPath(loader, StringUtils.split(auxJars, ","));
     }
+    conf.setClassLoader(loader);
+    Thread.currentThread().setContextClassLoader(loader);
 
     CliDriver cli = new CliDriver();
     int returnValue = 0;


### PR DESCRIPTION
Enables ReportalHiveRunner to work with Hive 0.13.

I just removed an unnecessary if block.

Tracked by internal JIRA: HADOOP-6627
