### PR TITLE
Make HadoopSecureHiveWrapper compatible with Hive 0.13

### DIFF
--- a/plugins/jobtype/src/azkaban/jobtype/HadoopSecureHiveWrapper.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopSecureHiveWrapper.java
@@ -152,21 +152,18 @@ public class HadoopSecureHiveWrapper {
       throw new IllegalArgumentException("Can't process empty args?!?");
     }
 
-    if (!ShimLoader.getHadoopShims().usesJobShell()) {
-      // hadoop-20 and above - we need to augment classpath using hiveconf
-      // components
-      // see also: code in ExecDriver.java
-      ClassLoader loader = hiveConf.getClassLoader();
-      String auxJars = HiveConf.getVar(hiveConf, HiveConf.ConfVars.HIVEAUXJARS);
-      logger.info("Got auxJars = " + auxJars);
+    // hadoop-20 and above - we need to augment classpath using hiveconf
+    // components
+    // see also: code in ExecDriver.java
+    ClassLoader loader = hiveConf.getClassLoader();
+    String auxJars = HiveConf.getVar(hiveConf, HiveConf.ConfVars.HIVEAUXJARS);
+    logger.info("Got auxJars = " + auxJars);
 
-      if (StringUtils.isNotBlank(auxJars)) {
-        loader =
-            Utilities.addToClassPath(loader, StringUtils.split(auxJars, ","));
-      }
-      hiveConf.setClassLoader(loader);
-      Thread.currentThread().setContextClassLoader(loader);
+    if (StringUtils.isNotBlank(auxJars)) {
+      loader = Utilities.addToClassPath(loader, StringUtils.split(auxJars, ","));
     }
+    hiveConf.setClassLoader(loader);
+    Thread.currentThread().setContextClassLoader(loader);
 
     // See https://issues.apache.org/jira/browse/HIVE-1411
     hiveConf.set("datanucleus.plugin.pluginRegistryBundleCheck", "LOG");


### PR DESCRIPTION
Fix for Issue #128.

Tracked by internal JIRA HADOOP-6554.
