### PR TITLE
Fix #138: HiveViaAzkaban/RealHiveQueryExecutor does not work with Hadoop...

### DIFF
--- a/plugins/jobtype/src/azkaban/jobtype/hiveutils/RealHiveQueryExecutor.java
+++ b/plugins/jobtype/src/azkaban/jobtype/hiveutils/RealHiveQueryExecutor.java
@@ -61,21 +61,16 @@ class RealHiveQueryExecutor implements HiveQueryExecutor {
       throw new IllegalArgumentException("Can't process empty args?!?");
     }
 
-    if (!ShimLoader.getHadoopShims().usesJobShell()) {
-      // hadoop-20 and above - we need to augment classpath using hiveconf
-      // components
-      // see also: code in ExecDriver.java
-      ClassLoader loader = hiveConf.getClassLoader();
-      String auxJars = HiveConf.getVar(hiveConf, HiveConf.ConfVars.HIVEAUXJARS);
-      LOG.info("Got auxJars = " + auxJars);
+    ClassLoader loader = hiveConf.getClassLoader();
+    String auxJars = HiveConf.getVar(hiveConf, HiveConf.ConfVars.HIVEAUXJARS);
+    LOG.info("Got auxJars = " + auxJars);
 
-      if (StringUtils.isNotBlank(auxJars)) {
-        loader =
-            Utilities.addToClassPath(loader, StringUtils.split(auxJars, ","));
-      }
-      hiveConf.setClassLoader(loader);
-      Thread.currentThread().setContextClassLoader(loader);
+    if (StringUtils.isNotBlank(auxJars)) {
+      loader =
+          Utilities.addToClassPath(loader, StringUtils.split(auxJars, ","));
     }
+    hiveConf.setClassLoader(loader);
+    Thread.currentThread().setContextClassLoader(loader);
 
     this.ss = ss;
     LOG.info("SessionState = " + ss);

--- a/plugins/reportal/src/azkaban/jobtype/ReportalHiveRunner.java
+++ b/plugins/reportal/src/azkaban/jobtype/ReportalHiveRunner.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.hive.cli.OptionsProcessor;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.session.SessionState;
-import org.apache.hadoop.hive.shims.ShimLoader;
 
 import azkaban.reportal.util.BoundedOutputStream;
 


### PR DESCRIPTION
I suggest using the Octosplit Chrome plugin (https://chrome.google.com/webstore/detail/octosplit/mnkacicafjlllhcedhhphhpapmdgjfbb) to view this diff -- enable "No whitespace" and you will see that all I did was delete the if() statement and the following comment lines.  I also removed an unused import to fix an Eclipse warning.
