### PR TITLE
Remove unused import to fix Eclipse warning

### DIFF
--- a/plugins/reportal/src/azkaban/jobtype/ReportalHiveRunner.java
+++ b/plugins/reportal/src/azkaban/jobtype/ReportalHiveRunner.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.hive.cli.OptionsProcessor;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.session.SessionState;
-import org.apache.hadoop.hive.shims.ShimLoader;
 
 import azkaban.reportal.util.BoundedOutputStream;
 


### PR DESCRIPTION
Just removing an unused import -- it's the only remaining Eclipse warning in this project
