### PR TITLE
HDFS viewer fails to render empty files

### DIFF
--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file-js.vm
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file-js.vm
@@ -92,6 +92,9 @@ azkaban.HdfsFileModel = Backbone.Model.extend({
       if (data.error != null) {
         model.set('error', data.error);
       }
+      if (data === '') {
+        data = 'Oops this is an empty file !!';
+      }
       model.set('contents', data);
     };
     $.get(requestURL, requestData, successHandler, 'text');


### PR DESCRIPTION
HDFA viewer has assumed that an ajax call is complete only when content on of azkaban.HdfsFileModel.get('contents') changes which does not occur in case of empty files.
