### PR TITLE
Ensure that mapred, yarn and hdfs site configuration files are added bef...

### DIFF
--- a/plugins/jobtype/src/azkaban/jobtype/HadoopConfigurationInjector.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopConfigurationInjector.java
@@ -40,6 +40,8 @@ import org.apache.log4j.Logger;
  */
 public class HadoopConfigurationInjector {
   private static Logger _logger = Logger.getLogger(HadoopConfigurationInjector.class);
+
+  // File to which the Hadoop configuration to inject will be written.
   private static final String INJECT_FILE = "hadoop-inject.xml";
 
   // Prefix for properties to be automatically injected into the Hadoop conf.
@@ -50,6 +52,17 @@ public class HadoopConfigurationInjector {
    * configuration properties to automatically inject.
    */
   public static void injectResources() {
+    // Add mapred, yarn and hdfs site configs (in addition to core-site, which
+    // is automatically added) as default resources before we add the injected
+    // configuration. This will cause the injected properties to override the
+    // default site properties (instead of vice-versa). This is safe to do,
+    // even when these site files don't exist for your Hadoop installation.
+    Configuration.addDefaultResource("mapred-default.xml");
+    Configuration.addDefaultResource("mapred-site.xml");
+    Configuration.addDefaultResource("yarn-default.xml");
+    Configuration.addDefaultResource("yarn-site.xml");
+    Configuration.addDefaultResource("hdfs-default.xml");
+    Configuration.addDefaultResource("hdfs-site.xml");
     Configuration.addDefaultResource(INJECT_FILE);
   }
 

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopConfigurationInjector.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopConfigurationInjector.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
@@ -50,19 +51,23 @@ public class HadoopConfigurationInjector {
   /*
    * To be called by the forked process to load the generated links and Hadoop
    * configuration properties to automatically inject.
+   *
+   * @param props The Azkaban properties
    */
-  public static void injectResources() {
+  public static void injectResources(Props props) {
     // Add mapred, yarn and hdfs site configs (in addition to core-site, which
     // is automatically added) as default resources before we add the injected
     // configuration. This will cause the injected properties to override the
     // default site properties (instead of vice-versa). This is safe to do,
     // even when these site files don't exist for your Hadoop installation.
-    Configuration.addDefaultResource("mapred-default.xml");
-    Configuration.addDefaultResource("mapred-site.xml");
-    Configuration.addDefaultResource("yarn-default.xml");
-    Configuration.addDefaultResource("yarn-site.xml");
-    Configuration.addDefaultResource("hdfs-default.xml");
-    Configuration.addDefaultResource("hdfs-site.xml");
+    if (props.getBoolean("azkaban.inject.hadoop-site.configs", true)) {
+      Configuration.addDefaultResource("mapred-default.xml");
+      Configuration.addDefaultResource("mapred-site.xml");
+      Configuration.addDefaultResource("yarn-default.xml");
+      Configuration.addDefaultResource("yarn-site.xml");
+      Configuration.addDefaultResource("hdfs-default.xml");
+      Configuration.addDefaultResource("hdfs-site.xml");
+    }
     Configuration.addDefaultResource(INJECT_FILE);
   }
 

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopJavaJobRunnerMain.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopJavaJobRunnerMain.java
@@ -100,7 +100,7 @@ public class HadoopJavaJobRunnerMain {
       Properties prop = new Properties();
       prop.load(new BufferedReader(new FileReader(propsFile)));
 
-      HadoopConfigurationInjector.injectResources();
+      HadoopConfigurationInjector.injectResources(new Props(null, prop));
 
       final Configuration conf = new Configuration();
 

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopJavaJobRunnerMain.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopJavaJobRunnerMain.java
@@ -97,10 +97,10 @@ public class HadoopJavaJobRunnerMain {
       appender.activateOptions();
       _logger.addAppender(appender);
 
-      Properties prop = new Properties();
-      prop.load(new BufferedReader(new FileReader(propsFile)));
+      Properties props = new Properties();
+      props.load(new BufferedReader(new FileReader(propsFile)));
 
-      HadoopConfigurationInjector.injectResources(new Props(null, prop));
+      HadoopConfigurationInjector.injectResources(new Props(null, props));
 
       final Configuration conf = new Configuration();
 
@@ -108,7 +108,7 @@ public class HadoopJavaJobRunnerMain {
       securityEnabled = UserGroupInformation.isSecurityEnabled();
 
       _logger.info("Running job " + _jobName);
-      String className = prop.getProperty(JOB_CLASS);
+      String className = props.getProperty(JOB_CLASS);
       if (className == null) {
         throw new Exception("Class name is not set.");
       }
@@ -117,8 +117,8 @@ public class HadoopJavaJobRunnerMain {
       UserGroupInformation loginUser = null;
       UserGroupInformation proxyUser = null;
 
-      if (shouldProxy(prop)) {
-        String userToProxy = prop.getProperty("user.to.proxy");
+      if (shouldProxy(props)) {
+        String userToProxy = props.getProperty("user.to.proxy");
         if (securityEnabled) {
           String filelocation = System.getenv(HADOOP_TOKEN_FILE_LOCATION);
           _logger.info("Found token file " + filelocation);
@@ -147,11 +147,11 @@ public class HadoopJavaJobRunnerMain {
       }
 
       // Create the object using proxy
-      if (shouldProxy(prop)) {
+      if (shouldProxy(props)) {
         _javaObject =
-            getObjectAsProxyUser(prop, _logger, _jobName, className, proxyUser);
+            getObjectAsProxyUser(props, _logger, _jobName, className, proxyUser);
       } else {
-        _javaObject = getObject(_jobName, className, prop, _logger);
+        _javaObject = getObject(_jobName, className, props, _logger);
       }
 
       if (_javaObject == null) {
@@ -161,15 +161,15 @@ public class HadoopJavaJobRunnerMain {
       _logger.info("Got object " + _javaObject.toString());
 
       _cancelMethod =
-          prop.getProperty(CANCEL_METHOD_PARAM, DEFAULT_CANCEL_METHOD);
+          props.getProperty(CANCEL_METHOD_PARAM, DEFAULT_CANCEL_METHOD);
 
       final String runMethod =
-          prop.getProperty(RUN_METHOD_PARAM, DEFAULT_RUN_METHOD);
+          props.getProperty(RUN_METHOD_PARAM, DEFAULT_RUN_METHOD);
       _logger.info("Invoking method " + runMethod);
 
-      if (shouldProxy(prop)) {
+      if (shouldProxy(props)) {
         _logger.info("Proxying enabled.");
-        runMethodAsUser(prop, _javaObject, runMethod, proxyUser);
+        runMethodAsUser(props, _javaObject, runMethod, proxyUser);
       } else {
         _logger.info("Proxy check failed, not proxying run.");
         runMethod(_javaObject, runMethod);
@@ -213,7 +213,7 @@ public class HadoopJavaJobRunnerMain {
     }
   }
 
-  private void runMethodAsUser(Properties prop, final Object obj,
+  private void runMethodAsUser(Properties props, final Object obj,
       final String runMethod, final UserGroupInformation ugi)
       throws IOException, InterruptedException {
     ugi.doAs(new PrivilegedExceptionAction<Void>() {
@@ -404,9 +404,9 @@ public class HadoopJavaJobRunnerMain {
     }
   }
 
-  public boolean shouldProxy(Properties prop) {
+  public boolean shouldProxy(Properties props) {
     String shouldProxy =
-        prop.getProperty(HadoopSecurityManager.ENABLE_PROXYING);
+        props.getProperty(HadoopSecurityManager.ENABLE_PROXYING);
 
     return shouldProxy != null && shouldProxy.equals("true");
   }

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopSecureHiveWrapper.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopSecureHiveWrapper.java
@@ -47,6 +47,7 @@ import org.apache.log4j.Logger;
 import azkaban.jobExecutor.ProcessJob;
 import azkaban.jobtype.hiveutils.HiveQueryExecutionException;
 import azkaban.security.commons.HadoopSecurityManager;
+import azkaban.utils.Props;
 
 public class HadoopSecureHiveWrapper {
 
@@ -67,7 +68,7 @@ public class HadoopSecureHiveWrapper {
     Properties prop = new Properties();
     prop.load(new BufferedReader(new FileReader(propsFile)));
 
-    HadoopConfigurationInjector.injectResources();
+    HadoopConfigurationInjector.injectResources(new Props(null, prop));
 
     hiveScript = prop.getProperty("hive.script");
 

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopSecureHiveWrapper.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopSecureHiveWrapper.java
@@ -65,21 +65,21 @@ public class HadoopSecureHiveWrapper {
   public static void main(final String[] args) throws Exception {
 
     String propsFile = System.getenv(ProcessJob.JOB_PROP_ENV);
-    Properties prop = new Properties();
-    prop.load(new BufferedReader(new FileReader(propsFile)));
+    Properties props = new Properties();
+    props.load(new BufferedReader(new FileReader(propsFile)));
 
-    HadoopConfigurationInjector.injectResources(new Props(null, prop));
+    HadoopConfigurationInjector.injectResources(new Props(null, props));
 
-    hiveScript = prop.getProperty("hive.script");
+    hiveScript = props.getProperty("hive.script");
 
     final Configuration conf = new Configuration();
 
     UserGroupInformation.setConfiguration(conf);
     securityEnabled = UserGroupInformation.isSecurityEnabled();
 
-    if (shouldProxy(prop)) {
+    if (shouldProxy(props)) {
       UserGroupInformation proxyUser = null;
-      String userToProxy = prop.getProperty("user.to.proxy");
+      String userToProxy = props.getProperty("user.to.proxy");
       if (securityEnabled) {
         String filelocation = System.getenv(HADOOP_TOKEN_FILE_LOCATION);
         if (filelocation == null) {
@@ -216,9 +216,9 @@ public class HadoopSecureHiveWrapper {
     }
   }
 
-  public static boolean shouldProxy(Properties prop) {
+  public static boolean shouldProxy(Properties props) {
     String shouldProxy =
-        prop.getProperty(HadoopSecurityManager.ENABLE_PROXYING);
+        props.getProperty(HadoopSecurityManager.ENABLE_PROXYING);
 
     return shouldProxy != null && shouldProxy.equals("true");
   }

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopSecurePigWrapper.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopSecurePigWrapper.java
@@ -166,8 +166,8 @@ public class HadoopSecurePigWrapper {
     }
   }
 
-  public static boolean shouldProxy(Props prop) {
-    String shouldProxy = prop.getString(HadoopSecurityManager.ENABLE_PROXYING);
+  public static boolean shouldProxy(Props props) {
+    String shouldProxy = props.getString(HadoopSecurityManager.ENABLE_PROXYING);
     return shouldProxy != null && shouldProxy.equals("true");
   }
 }

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopSecurePigWrapper.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopSecurePigWrapper.java
@@ -84,7 +84,7 @@ public class HadoopSecurePigWrapper {
     String propsFile = System.getenv(ProcessJob.JOB_PROP_ENV);
     props = new Props(null, new File(propsFile));
 
-    HadoopConfigurationInjector.injectResources();
+    HadoopConfigurationInjector.injectResources(props);
 
     final Configuration conf = new Configuration();
 

--- a/plugins/jobtype/src/azkaban/jobtype/JavaJobRunnerMain.java
+++ b/plugins/jobtype/src/azkaban/jobtype/JavaJobRunnerMain.java
@@ -104,7 +104,7 @@ public class JavaJobRunnerMain {
       }
       _logger.info("Class name " + className);
 
-      HadoopConfigurationInjector.injectResources();
+      HadoopConfigurationInjector.injectResources(new Props(null, prop));
 
       // Create the object using proxy
       if (SecurityUtils.shouldProxy(prop)) {

--- a/plugins/jobtype/src/azkaban/jobtype/JavaJobRunnerMain.java
+++ b/plugins/jobtype/src/azkaban/jobtype/JavaJobRunnerMain.java
@@ -94,23 +94,23 @@ public class JavaJobRunnerMain {
       appender.activateOptions();
       _logger.addAppender(appender);
 
-      Properties prop = new Properties();
-      prop.load(new BufferedReader(new FileReader(propsFile)));
+      Properties props = new Properties();
+      props.load(new BufferedReader(new FileReader(propsFile)));
 
       _logger.info("Running job " + _jobName);
-      String className = prop.getProperty(JOB_CLASS);
+      String className = props.getProperty(JOB_CLASS);
       if (className == null) {
         throw new Exception("Class name is not set.");
       }
       _logger.info("Class name " + className);
 
-      HadoopConfigurationInjector.injectResources(new Props(null, prop));
+      HadoopConfigurationInjector.injectResources(new Props(null, props));
 
       // Create the object using proxy
-      if (SecurityUtils.shouldProxy(prop)) {
-        _javaObject = getObjectAsProxyUser(prop, _logger, _jobName, className);
+      if (SecurityUtils.shouldProxy(props)) {
+        _javaObject = getObjectAsProxyUser(props, _logger, _jobName, className);
       } else {
-        _javaObject = getObject(_jobName, className, prop, _logger);
+        _javaObject = getObject(_jobName, className, props, _logger);
       }
       if (_javaObject == null) {
         _logger.info("Could not create java object to run job: " + className);
@@ -118,15 +118,15 @@ public class JavaJobRunnerMain {
       }
 
       _cancelMethod =
-          prop.getProperty(CANCEL_METHOD_PARAM, DEFAULT_CANCEL_METHOD);
+          props.getProperty(CANCEL_METHOD_PARAM, DEFAULT_CANCEL_METHOD);
 
       final String runMethod =
-          prop.getProperty(RUN_METHOD_PARAM, DEFAULT_RUN_METHOD);
+          props.getProperty(RUN_METHOD_PARAM, DEFAULT_RUN_METHOD);
       _logger.info("Invoking method " + runMethod);
 
-      if (SecurityUtils.shouldProxy(prop)) {
+      if (SecurityUtils.shouldProxy(props)) {
         _logger.info("Proxying enabled.");
-        runMethodAsProxyUser(prop, _javaObject, runMethod);
+        runMethodAsProxyUser(props, _javaObject, runMethod);
       } else {
         _logger.info("Proxy check failed, not proxying run.");
         runMethod(_javaObject, runMethod);
@@ -168,15 +168,15 @@ public class JavaJobRunnerMain {
     }
   }
 
-  private void runMethodAsProxyUser(Properties prop, final Object obj,
+  private void runMethodAsProxyUser(Properties props, final Object obj,
       final String runMethod) throws IOException, InterruptedException {
     UserGroupInformation ugi =
-        SecurityUtils.getProxiedUser(prop, _logger, new Configuration());
+        SecurityUtils.getProxiedUser(props, _logger, new Configuration());
     _logger.info("user " + ugi + " authenticationMethod "
         + ugi.getAuthenticationMethod());
     _logger.info("user " + ugi + " hasKerberosCredentials "
         + ugi.hasKerberosCredentials());
-    SecurityUtils.getProxiedUser(prop, _logger, new Configuration()).doAs(
+    SecurityUtils.getProxiedUser(props, _logger, new Configuration()).doAs(
         new PrivilegedExceptionAction<Void>() {
           @Override
           public Void run() throws Exception {
@@ -262,15 +262,15 @@ public class JavaJobRunnerMain {
     }
   }
 
-  private static Object getObjectAsProxyUser(final Properties prop,
+  private static Object getObjectAsProxyUser(final Properties props,
       final Logger logger, final String jobName, final String className)
       throws Exception {
     Object obj =
-        SecurityUtils.getProxiedUser(prop, logger, new Configuration()).doAs(
+        SecurityUtils.getProxiedUser(props, logger, new Configuration()).doAs(
             new PrivilegedExceptionAction<Object>() {
               @Override
               public Object run() throws Exception {
-                return getObject(jobName, className, prop, logger);
+                return getObject(jobName, className, props, logger);
               }
             });
 


### PR DESCRIPTION
...ore the configuration file containing properties to inject.

Currently, injected properties are being overridden by properties appearing in the site configs. This pull request will fix this problem. Users will not be able to override properties marked "final" in the site configs, which is a good thing.

I checked all the Hadoop source code to make sure that adding the site configs here is safe to do in both Hadoop 1 and Hadoop 2. Adding them is safe even if you Hadoop installation does not have one of the listed site config files.

Tested successfully on lva1-spadesaz01 (an internal node at LinkedIn).