### PR TITLE
removing ':' char from directory name of hadoop injects

### DIFF
--- a/plugins/jobtype/src/azkaban/jobtype/HadoopConfigurationInjector.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopConfigurationInjector.java
@@ -157,10 +157,10 @@ public class HadoopConfigurationInjector {
    * @param props The Azkaban properties
    */
   public static String getDirName(Props props) {
-    String dirSuffix = props.get("azkaban.flow.nested.path");
+    String dirSuffix = props.get(CommonJobProperties.NESTED_FLOW_PATH);
 
     if ((dirSuffix == null) || (dirSuffix.length() == 0)) {
-      dirSuffix = props.get("azkaban.job.id");
+      dirSuffix = props.get(CommonJobProperties.JOB_ID);
       if ((dirSuffix == null) || (dirSuffix.length() == 0)) {
         throw new RuntimeException("azkaban.flow.nested.path and azkaban.job.id were not set");
       }

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopConfigurationInjector.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopConfigurationInjector.java
@@ -166,7 +166,7 @@ public class HadoopConfigurationInjector {
       }
     }
 
-    return "_resources_" + dirSuffix;
+    return "_resources_" + dirSuffix.replace(':', '_');
   }
 
   /**


### PR DESCRIPTION
There are colons between the embedded flow name and the job name. When this folder gets added to the Java classpath, it gets split into two classpath entries, which causes the hadoop-inject.xml file inside the resources folder not to be picked up.