### PR TITLE
Revert fix for #180 because it's unnecessary

### DIFF
--- a/plugins/jobtype/src/azkaban/jobtype/HadoopPigJob.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopPigJob.java
@@ -85,11 +85,6 @@ public class HadoopPigJob extends JavaProcessJob {
     obtainTokens = getSysProps().getBoolean("obtain.binary.token", false);
     userPigJar = getJobProps().getBoolean("use.user.pig.jar", false);
 
-    // Fetch HCatalog token if enabled
-    boolean obtainHcatToken = getSysProps().getBoolean(HadoopSecurityManager.OBTAIN_HCAT_TOKEN, false);
-    obtainHcatToken = getJobProps().getBoolean(HadoopSecurityManager.OBTAIN_HCAT_TOKEN, obtainHcatToken);
-    getSysProps().put(HadoopSecurityManager.OBTAIN_HCAT_TOKEN, Boolean.toString(obtainHcatToken));
-
     if (shouldProxy) {
       getLog().info("Initiating hadoop security manager.");
       try {


### PR DESCRIPTION
It's unnecessary because the actual token-fetching happens in the [call on line 116](https://github.com/azkaban/azkaban-plugins/blob/master/plugins/jobtype/src/azkaban/jobtype/HadoopPigJob.java#L116), and the props passed are a combination of JobProps and SysProps.  So if a user sets `obtain.hcat.token` in his job properties, it already gets picked up without adding the setting to SysProps.

Thus, I'm reverting the part that adds the property to SysProps but am keeping the formatting and other changes.