### PR TITLE
Add a report view link in reportal notification

### DIFF
--- a/plugins/reportal/src/azkaban/viewer/reportal/ReportalMailCreator.java
+++ b/plugins/reportal/src/azkaban/viewer/reportal/ReportalMailCreator.java
@@ -140,6 +140,9 @@ public class ReportalMailCreator implements MailCreator {
         .println("<div style='font-size: .8em; margin-top: .5em; margin-bottom: .5em;'>");
     // Status
     message.println(flow.getStatus().name());
+    // Link to View
+    message.println("(<a href='" + urlPrefix + "?view&id="
+        + flow.getProjectId() + "'>View</a>)");
     // Link to logs
     message.println("(<a href='" + urlPrefix + "?view&logs&id="
         + flow.getProjectId() + "&execid=" + flow.getExecutionId()


### PR DESCRIPTION
 Modify reportal notification emails to include a link to the report, so people don’t have to search Reportal for the report title.