### PR TITLE
fix Bad property definition! null exception

### DIFF
--- a/plugins/jobtype/src/azkaban/jobtype/HadoopConfigurationInjector.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopConfigurationInjector.java
@@ -78,7 +78,9 @@ public class HadoopConfigurationInjector {
       for (Map.Entry<String, String> entry : confProperties.entrySet()) {
         String confKey = entry.getKey().replace(INJECT_PREFIX, "");
         String confVal = entry.getValue();
-        conf.set(confKey, confVal);
+        if (confVal != null) {
+          conf.set(confKey, confVal);
+        }
       }
 
       // Now write out the configuration file to inject.


### PR DESCRIPTION
fix the exception below:

09-09-2015 20:31:46 CST hive-demo INFO - Starting job hive-demo at 1441801906212
09-09-2015 20:31:46 CST hive-demo INFO - azkaban.webserver.url property was not set
09-09-2015 20:31:46 CST hive-demo INFO - job JVM args: -Dazkaban.flowid=hive-demo -Dazkaban.execid=29 -Dazkaban.jobid=hive-demo
09-09-2015 20:31:46 CST hive-demo INFO - Building hive job executor. 
09-09-2015 20:31:46 CST hive-demo ERROR - Bad property definition! null
09-09-2015 20:31:46 CST hive-demo ERROR - caught exception running the job
09-09-2015 20:31:46 CST hive-demo ERROR - Job run failed!
java.lang.Exception: java.lang.Exception: Bad property definition! null
        at azkaban.jobtype.HadoopHiveJob.run(HadoopHiveJob.java:103)
        at azkaban.execapp.JobRunner.runJob(JobRunner.java:590)
        at azkaban.execapp.JobRunner.run(JobRunner.java:443)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
        at java.util.concurrent.FutureTask.run(FutureTask.java:262)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.Exception: Bad property definition! null
        at azkaban.jobExecutor.ProcessJob.handleError(ProcessJob.java:107)
        at azkaban.jobExecutor.ProcessJob.run(ProcessJob.java:50)
        at azkaban.jobtype.HadoopHiveJob.run(HadoopHiveJob.java:99)
        ... 7 more
Caused by: java.lang.NullPointerException
        at java.util.regex.Matcher.getTextLength(Matcher.java:1234)
        at java.util.regex.Matcher.reset(Matcher.java:308)
        at java.util.regex.Matcher.(Matcher.java:228)
        at java.util.regex.Pattern.matcher(Pattern.java:1088)
        at azkaban.utils.PropsUtils.resolveVariableReplacement(PropsUtils.java:177)
        at azkaban.utils.PropsUtils.resolveProps(PropsUtils.java:156)
        at azkaban.jobExecutor.AbstractProcessJob.resolveProps(AbstractProcessJob.java:81)
        at azkaban.jobExecutor.ProcessJob.run(ProcessJob.java:48)
        ... 8 more
09-09-2015 20:31:46 CST hive-demo ERROR - java.lang.Exception: Bad property definition! null cause: java.lang.Exception: Bad property definition! null
09-09-2015 20:31:46 CST hive-demo INFO - Finishing job hive-demo attempt: 0 at 1441801906269 with status FAILED