### PR TITLE
Allowing users to specify global job properties using reportal variables

### DIFF
--- a/plugins/reportal/src/azkaban/reportal/util/Reportal.java
+++ b/plugins/reportal/src/azkaban/reportal/util/Reportal.java
@@ -53,6 +53,11 @@ import azkaban.viewer.reportal.ReportalTypeManager;
 
 public class Reportal {
   public static final String REPORTAL_CONFIG_PREFIX = "reportal.config.";
+  public static final String REPORTAL_CONFIG_PREFIX_REGEX =
+    "^reportal[.]config[.].+";
+  public static final String REPORTAL_CONFIG_PREFIX_NEGATION_REGEX =
+    "(?!(^reportal[.]config[.])).+";
+
   public static final String ACCESS_LIST_SPLIT_REGEX =
       "\\s*,\\s*|\\s*;\\s*|\\s+";
 
@@ -266,8 +271,8 @@ public class Reportal {
 
       // Populate the job file
       ReportalTypeManager.createJobAndFiles(this, jobFile, jobName,
-        query.title, query.type, query.script, dependentJob, reportalUser,
-        extraProps);
+          query.title, query.type, query.script, dependentJob, reportalUser,
+          extraProps);
 
       // For dependency of next query
       dependentJob = jobName;

--- a/plugins/reportal/src/azkaban/reportal/util/Reportal.java
+++ b/plugins/reportal/src/azkaban/reportal/util/Reportal.java
@@ -46,11 +46,13 @@ import azkaban.scheduler.ScheduleManagerException;
 import azkaban.user.Permission;
 import azkaban.user.Permission.Type;
 import azkaban.user.User;
+import azkaban.utils.Props;
 import azkaban.utils.Utils;
 import azkaban.viewer.reportal.ReportalMailCreator;
 import azkaban.viewer.reportal.ReportalTypeManager;
 
 public class Reportal {
+  public static final String REPORTAL_CONFIG_PREFIX = "reportal.config.";
   public static final String ACCESS_LIST_SPLIT_REGEX =
       "\\s*,\\s*|\\s*;\\s*|\\s+";
 
@@ -250,6 +252,8 @@ public class Reportal {
     // Create all job files
     String dependentJob = null;
     List<String> jobs = new ArrayList<String>();
+    Map<String, String> extraProps =
+      ReportalUtil.getVariableMapByPrefix(variables, REPORTAL_CONFIG_PREFIX);
     for (Query query : queries) {
       // Create .job file
       File jobFile =
@@ -262,8 +266,8 @@ public class Reportal {
 
       // Populate the job file
       ReportalTypeManager.createJobAndFiles(this, jobFile, jobName,
-          query.title, query.type, query.script, dependentJob, reportalUser,
-          null);
+        query.title, query.type, query.script, dependentJob, reportalUser,
+        extraProps);
 
       // For dependency of next query
       dependentJob = jobName;
@@ -400,12 +404,12 @@ public class Reportal {
     reportal.variables = new ArrayList<Variable>();
 
     for (int i = 0; i < variables; i++) {
-      Variable variable = new Variable();
-      reportal.variables.add(variable);
-      variable.title =
+      String title =
           stringGetter.get(project.getMetadata().get("variable" + i + "title"));
-      variable.name =
+      String name =
           stringGetter.get(project.getMetadata().get("variable" + i + "name"));
+      Variable variable = new Variable(title, name);
+      reportal.variables.add(variable);
     }
 
     reportal.project = project;
@@ -459,6 +463,13 @@ public class Reportal {
   public static class Variable {
     public String title;
     public String name;
+
+    public Variable() {}
+
+    public Variable(String title, String name) {
+      this.title = title;
+      this.name = name;
+    }
 
     public String getTitle() {
       return title;

--- a/plugins/reportal/src/azkaban/reportal/util/ReportalUtil.java
+++ b/plugins/reportal/src/azkaban/reportal/util/ReportalUtil.java
@@ -73,14 +73,14 @@ public class ReportalUtil {
   public static List<Variable> getRunTimeVariables(
     Collection<Variable> variables) {
     List<Variable> runtimeVariables =
-      ReportalUtil.getVariablesByRegex(variables, "(?!(^"
-        + Reportal.REPORTAL_CONFIG_PREFIX + ")).+");
+      ReportalUtil.getVariablesByRegex(variables,
+        Reportal.REPORTAL_CONFIG_PREFIX_NEGATION_REGEX);
 
     return runtimeVariables;
   }
 
   /**
-   * Shortlist variables which match a given regex. Returns empty props, if no
+   * Shortlist variables which match a given regex. Returns empty empty list, if no
    * eligible variable is found
    *
    * @param variables
@@ -90,7 +90,7 @@ public class ReportalUtil {
   public static List<Variable> getVariablesByRegex(
     Collection<Variable> variables, String regex) {
     List<Variable> shortlistedVariables = new ArrayList<Variable>();
-    if (variables != null || regex == null) {
+    if (variables != null && regex != null) {
       for (Variable var : variables) {
         if (var.getTitle().matches(regex)) {
           shortlistedVariables.add(var);
@@ -101,7 +101,7 @@ public class ReportalUtil {
   }
 
   /**
-   * Shortlist variables which match a given prefix. Returns empty props, if no
+   * Shortlist variables which match a given prefix. Returns empty map, if no
    * eligible variable is found.
    *
    * @param variables
@@ -113,8 +113,9 @@ public class ReportalUtil {
   public static Map<String, String> getVariableMapByPrefix(
     Collection<Variable> variables, String prefix) {
     Map<String, String> shortlistMap = new HashMap<String, String>();
-    if (prefix != null) {
-      for (Variable var : getVariablesByRegex(variables, "^" + prefix + ".+")) {
+    if (variables!=null && prefix != null) {
+      for (Variable var : getVariablesByRegex(variables,
+        Reportal.REPORTAL_CONFIG_PREFIX_REGEX)) {
         shortlistMap
           .put(var.getTitle().replaceFirst(prefix, ""), var.getName());
       }

--- a/plugins/reportal/src/azkaban/reportal/util/ReportalUtil.java
+++ b/plugins/reportal/src/azkaban/reportal/util/ReportalUtil.java
@@ -17,11 +17,16 @@
 package azkaban.reportal.util;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutableNode;
+import azkaban.reportal.util.Reportal.Variable;
+import azkaban.utils.Props;
 
 public class ReportalUtil {
   public static IStreamProvider getStreamProvider(String fileSystem) {
@@ -56,5 +61,64 @@ public class ReportalUtil {
     }
 
     return sortedNodes;
+  }
+
+  /**
+   * Get runtime variables to be set in unscheduled mode of execution.
+   * Returns empty list, if no runtime variable is found
+   *
+   * @param variables
+   * @return
+   */
+  public static List<Variable> getRunTimeVariables(
+    Collection<Variable> variables) {
+    List<Variable> runtimeVariables =
+      ReportalUtil.getVariablesByRegex(variables, "(?!(^"
+        + Reportal.REPORTAL_CONFIG_PREFIX + ")).+");
+
+    return runtimeVariables;
+  }
+
+  /**
+   * Shortlist variables which match a given regex. Returns empty props, if no
+   * eligible variable is found
+   *
+   * @param variables
+   * @param regex
+   * @return
+   */
+  public static List<Variable> getVariablesByRegex(
+    Collection<Variable> variables, String regex) {
+    List<Variable> shortlistedVariables = new ArrayList<Variable>();
+    if (variables != null || regex == null) {
+      for (Variable var : variables) {
+        if (var.getTitle().matches(regex)) {
+          shortlistedVariables.add(var);
+        }
+      }
+    }
+    return shortlistedVariables;
+  }
+
+  /**
+   * Shortlist variables which match a given prefix. Returns empty props, if no
+   * eligible variable is found.
+   *
+   * @param variables
+   *          variables to be processed
+   * @param prefix
+   *          prefix to be matched
+   * @return a map with shortlisted variables and prefix removed
+   */
+  public static Map<String, String> getVariableMapByPrefix(
+    Collection<Variable> variables, String prefix) {
+    Map<String, String> shortlistMap = new HashMap<String, String>();
+    if (prefix != null) {
+      for (Variable var : getVariablesByRegex(variables, "^" + prefix + ".+")) {
+        shortlistMap
+          .put(var.getTitle().replaceFirst(prefix, ""), var.getName());
+      }
+    }
+    return shortlistMap;
   }
 }

--- a/plugins/reportal/src/azkaban/viewer/reportal/ReportalServlet.java
+++ b/plugins/reportal/src/azkaban/viewer/reportal/ReportalServlet.java
@@ -629,9 +629,11 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
     page.add("title", reportal.title);
     page.add("description", reportal.description);
 
-    if (reportal.variables.size() > 0) {
-      page.add("variableNumber", reportal.variables.size());
-      page.add("variables", reportal.variables);
+    List<Variable> runtimeVariables =
+      ReportalUtil.getRunTimeVariables(reportal.variables);
+    if (runtimeVariables.size() > 0) {
+      page.add("variableNumber", runtimeVariables.size());
+      page.add("variables", runtimeVariables);
     }
 
     page.render();
@@ -865,10 +867,9 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
     report.variables = variableList;
 
     for (int i = 0; i < variables; i++) {
-      Variable variable = new Variable();
-
-      variable.title = getParam(req, "variable" + i + "title");
-      variable.name = getParam(req, "variable" + i + "name");
+      Variable variable =
+        new Variable(getParam(req, "variable" + i + "title"), getParam(req,
+          "variable" + i + "name"));
 
       if (variable.title.isEmpty() || variable.name.isEmpty()) {
         errors.add("Variable title and name cannot be empty.");
@@ -1139,7 +1140,7 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
     ExecutionOptions options = exflow.getExecutionOptions();
 
     int i = 0;
-    for (Variable variable : report.variables) {
+    for (Variable variable : ReportalUtil.getRunTimeVariables(report.variables)) {
       options.getFlowParameters().put(REPORTAL_VARIABLE_PREFIX + i + ".from",
           variable.name);
       options.getFlowParameters().put(REPORTAL_VARIABLE_PREFIX + i + ".to",

--- a/plugins/reportal/unit/azkaban/test/reportal/util/ReportalUtilTest.java
+++ b/plugins/reportal/unit/azkaban/test/reportal/util/ReportalUtilTest.java
@@ -18,6 +18,7 @@ package azkaban.test.reportal.util;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -28,9 +29,135 @@ import azkaban.flow.Edge;
 import azkaban.flow.Flow;
 import azkaban.flow.Node;
 import azkaban.project.Project;
+import azkaban.reportal.util.Reportal.Variable;
 import azkaban.reportal.util.ReportalUtil;
 
 public class ReportalUtilTest {
+
+  @Test
+  public void testGetVariableMapByPrefixNullVariables() {
+    Map<String, String> prefixMap =
+      ReportalUtil.getVariableMapByPrefix(null, "dummyPrefix");
+    Assert.assertTrue(
+      "shortlistedVariables was not empty but was expected to be.",
+      prefixMap.isEmpty());
+  }
+
+  @Test
+  public void testGetVariableMapByPrefixNullPrefix() {
+    List<Variable> variables = getVariablesForTest();
+    Map<String, String> prefixMap =
+      ReportalUtil.getVariableMapByPrefix(variables, null);
+    Assert.assertTrue(
+      "shortlistedVariables was not empty but was expected to be.",
+      prefixMap.isEmpty());
+  }
+
+  @Test
+  public void testGetVariableMapByPrefixNoMatch() {
+    List<Variable> variables = getVariablesForTest();
+    Map<String, String> prefixMap =
+      ReportalUtil.getVariableMapByPrefix(variables, "dummyPrefix");
+    Assert.assertTrue(
+      "shortlistedVariables was not empty but was expected to be.",
+      prefixMap.isEmpty());
+  }
+
+  @Test
+  public void testGetVariableMapByPrefixMatch() {
+    List<Variable> variables = getVariablesForTest();
+    variables.add(new Variable("dummyPrefix.title", "dummyName1"));
+    variables.add(new Variable("mydummyPrefix.title", "dummyName2"));
+
+    Map<String, String> prefixMap =
+      ReportalUtil.getVariableMapByPrefix(variables, "dummyPrefix");
+
+    Assert.assertEquals(1, prefixMap.size());
+    Assert.assertEquals(prefixMap.get("title"), "dummyName1");
+  }
+
+  @Test
+  public void testGetVariablesByRegexNullVariables() {
+    List<Variable> shortlistedVariables =
+      ReportalUtil.getVariablesByRegex(null, "dummyPrefix");
+    Assert.assertTrue(
+      "shortlistedVariables was not empty but was expected to be.",
+      shortlistedVariables.isEmpty());
+  }
+
+  @Test
+  public void testGetVariablesByRegexNullPrefix() {
+    List<Variable> variables = getVariablesForTest();
+    List<Variable> shortlistedVariables =
+      ReportalUtil.getVariablesByRegex(variables, null);
+    Assert.assertTrue(
+      "shortlistedVariables was not empty but was expected to be.",
+      shortlistedVariables.isEmpty());
+  }
+
+  @Test
+  public void testGetVariablesByRegexNoMatch() {
+    List<Variable> variables = getVariablesForTest();
+    List<Variable> shortlistedVariables =
+      ReportalUtil.getVariablesByRegex(variables, "dummyPrefix");
+    Assert.assertTrue(
+      "shortlistedVariables was not empty but was expected to be.",
+      shortlistedVariables.isEmpty());
+  }
+
+  @Test
+  public void testGetVariablesByRegexMatch() {
+    List<Variable> variables = getVariablesForTest();
+    variables.add(new Variable("dummyPrefix.title", "dummyName1"));
+    variables.add(new Variable("mydummyPrefix.title", "dummyName2"));
+
+    List<Variable> shortlistedVariables =
+      ReportalUtil.getVariablesByRegex(variables, "^dummyPrefix");
+
+    Assert.assertEquals(1, shortlistedVariables.size());
+    Assert.assertEquals(shortlistedVariables.get(0).getName(), "dummyName1");
+  }
+
+  @Test
+  public void testGetRunTimeNullVariables() {
+    List<Variable> shortlistedVariables =
+      ReportalUtil.getRunTimeVariables(null);
+    Assert.assertTrue("RunTimeVariables was not empty but was expected to be.",
+      shortlistedVariables.isEmpty());
+  }
+
+  @Test
+  public void testGetRunTimeVariablesNoMatch() {
+    List<Variable> variables = new ArrayList<Variable>();
+    List<Variable> shortlistedVariables =
+      ReportalUtil.getRunTimeVariables(variables);
+    Assert.assertTrue("RunTimeVariables was not empty but was expected to be.",
+      shortlistedVariables.isEmpty());
+  }
+
+  @Test
+  public void testGetRunTimeVariables() {
+    List<Variable> variables = getVariablesForTest();
+    variables.add(new Variable("reportal.config.title", "dummyName1"));
+
+    List<Variable> shortlistedVariables =
+      ReportalUtil.getRunTimeVariables(variables);
+
+    Assert.assertEquals(3, shortlistedVariables.size());
+    for (int index = 0; index < variables.size(); ++index) {
+      Assert
+        .assertEquals(variables.get(index), shortlistedVariables.get(index));
+    }
+  }
+
+  /* Dummy data for test cases */
+  private List<Variable> getVariablesForTest() {
+    List<Variable> variables = new ArrayList<Variable>();
+    variables.add(new Variable("title1", "name1"));
+    variables.add(new Variable("title2", "name2"));
+    variables.add(new Variable("title3", "name3"));
+    return variables;
+  }
 
   @Test
   public void testSortExecutableNodesNullFlow() {


### PR DESCRIPTION
* Allowing users to specify global job properties using reportal variables. All variables with prefix reportal.config will be considered for job properties.
* Allowing users to override pig.home from reportal variable using reportal.config.pig.home