### PR TITLE
HadoopSecurePigWrapper has a special feature that reads the pig log f…

### DIFF
--- a/plugins/jobtype/src/azkaban/jobtype/HadoopSecurePigWrapper.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopSecurePigWrapper.java
@@ -57,6 +57,10 @@ public class HadoopSecurePigWrapper {
     Properties jobProps = HadoopSecureWrapperUtils.loadAzkabanProps();
     props = new Props(null, jobProps);
     HadoopConfigurationInjector.injectResources(props);
+    
+    // special feature of secure pig wrapper: we will append the pig error file
+    // onto system out
+    pigLogFile = new File(System.getenv("PIG_LOG_FILE"));
 
     if (HadoopSecureWrapperUtils.shouldProxy(jobProps)) {
       String tokenFile = System.getenv(HADOOP_TOKEN_FILE_LOCATION);


### PR DESCRIPTION
…ile and prints everything in it onto standard out (so that you can see it from the Azkaban logs).  This was accidentally removed, and so adding it back in