### PR TITLE
Azkaban HadoopShell jobtype

### DIFF
--- a/plugins/jobtype/jobtypes/hadoopShell/plugin.properties
+++ b/plugins/jobtype/jobtypes/hadoopShell/plugin.properties
@@ -1,0 +1,1 @@
+hadoop.global.opts=-Dazkaban.link.attempt.url=${azkaban.link.attempt.url} -Dazkaban.link.job.url=${azkaban.link.job.url} -Dazkaban.link.execution.url=${azkaban.link.execution.url}

--- a/plugins/jobtype/jobtypes/hadoopShell/private.properties
+++ b/plugins/jobtype/jobtypes/hadoopShell/private.properties
@@ -1,0 +1,3 @@
+jobtype.class=azkaban.jobtype.HadoopShell
+
+command.blacklist.regex=(?i).*kinit.*

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopJobUtils.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopJobUtils.java
@@ -25,7 +25,10 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.PrivilegedExceptionAction;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -63,7 +66,10 @@ import azkaban.utils.Props;
  */
 
 public class HadoopJobUtils {
+  public static String MATCH_ALL_REGEX = ".*";
 
+  public static String MATCH_NONE_REGEX = ".^";
+  
   public static final String HADOOP_SECURITY_MANAGER_CLASS_PARAM = "hadoop.security.manager.class";
 
   // the regex to look for while looking for application id's in the hadoop log
@@ -481,6 +487,36 @@ public class HadoopJobUtils {
     return String.format("-D%s=%s", key, value);
   }
   
+  /**
+   * Filter a collection of String commands to match a whitelist regex and not match a blacklist
+   * regex.
+   * 
+   * @param commands
+   *          Collection of commands to be filtered
+   * @param whitelistRegex
+   *          whitelist regex to work as inclusion criteria
+   * @param blacklistRegex
+   *          blacklist regex to work as exclusion criteria
+   * @param log
+   *          logger to report violation
+   * @return filtered list of matching. Empty list if no command match all the criteria.
+   */
+  public static List<String> filterCommands(Collection<String> commands, String whitelistRegex,
+          String blacklistRegex, Logger log) {
+    List<String> filteredCommands = new LinkedList<String>();
+    Pattern whitelistPattern = Pattern.compile(whitelistRegex);
+    Pattern blacklistPattern = Pattern.compile(blacklistRegex);
+    for (String command : commands) {
+      if (whitelistPattern.matcher(command).matches()
+              && !blacklistPattern.matcher(command).matches()) {
+        filteredCommands.add(command);
+      } else {
+        log.warn(String.format("Removing restricted command: %s", command));
+      }
+    }
+    return filteredCommands;
+  }
+
   /**
    * <pre>
    * constructions a javaOpts string based on the Props, and the key given, will return 

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopShell.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopShell.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.jobtype;
+
+import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.log4j.Logger;
+
+import azkaban.flow.CommonJobProperties;
+import azkaban.jobExecutor.ProcessJob;
+import azkaban.security.commons.HadoopSecurityManager;
+import azkaban.utils.Props;
+
+/**
+ * HadoopShell is a Hadoop security enabled "command" jobtype. This jobtype
+ * adheres to same format and other details as "command" jobtype.
+ * 
+ * @author gaggarwa
+ *
+ */
+public class HadoopShell extends ProcessJob {
+	private String userToProxy = null;
+	private boolean shouldProxy = false;
+	private boolean obtainTokens = false;
+	private File tokenFile = null;
+	public static final String HADOOP_OPTS = ENV_PREFIX + "HADOOP_OPTS";
+	public static final String HADOOP_GLOBAL_OPTS = "hadoop.global.opts";
+	public static final String WHITELIST_REGEX = "command.whitelist.regex";
+	public static final String BLACKLIST_REGEX = "command.blacklist.regex";
+
+	private HadoopSecurityManager hadoopSecurityManager;
+
+	public HadoopShell(String jobid, Props sysProps, Props jobProps, Logger log) throws RuntimeException {
+		super(jobid, sysProps, jobProps, log);
+
+		shouldProxy = getSysProps().getBoolean(HadoopSecurityManager.ENABLE_PROXYING, false);
+		getJobProps().put(HadoopSecurityManager.ENABLE_PROXYING, Boolean.toString(shouldProxy));
+		obtainTokens = getSysProps().getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN, false);
+
+		if (shouldProxy) {
+			getLog().info("Initiating hadoop security manager.");
+			try {
+				hadoopSecurityManager = HadoopJobUtils.loadHadoopSecurityManager(getSysProps(), log);
+			} catch (RuntimeException e) {
+				e.printStackTrace();
+				throw new RuntimeException("Failed to get hadoop security manager!" + e.getCause());
+			}
+		}
+	}
+
+	@Override
+	public void run() throws Exception {
+		setupHadoopOpts(getJobProps());
+		HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(), getWorkingDirectory());
+		if (shouldProxy && obtainTokens) {
+			userToProxy = getJobProps().getString("user.to.proxy");
+			getLog().info("Need to proxy. Getting tokens.");
+			Props props = new Props();
+			props.putAll(getJobProps());
+			props.putAll(getSysProps());
+
+			tokenFile = HadoopJobUtils.getHadoopTokens(hadoopSecurityManager, props, getLog());
+			getJobProps().put("env." + HADOOP_TOKEN_FILE_LOCATION, tokenFile.getAbsolutePath());
+		}
+		try {
+			super.run();
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new Exception(e);
+		} finally {
+			if (tokenFile != null) {
+				try {
+					HadoopJobUtils.cancelHadoopTokens(hadoopSecurityManager, userToProxy, tokenFile, getLog());
+				} catch (Throwable t) {
+					t.printStackTrace();
+					getLog().error("Failed to cancel tokens.");
+				}
+				if (tokenFile.exists()) {
+					tokenFile.delete();
+				}
+			}
+		}
+	}
+
+	/**
+	 * Append HADOOP_GLOBAL_OPTS with HADOOP_OPTS in the given props
+	 * 
+	 * @param props
+	 */
+	private void setupHadoopOpts(Props props) {
+		if (props.containsKey(HADOOP_GLOBAL_OPTS)) {
+			String hadoopGlobalOps = props.getString(HADOOP_GLOBAL_OPTS);
+			if (props.containsKey(HADOOP_OPTS)) {
+				String hadoopOps = props.getString(HADOOP_OPTS);
+				props.put(HADOOP_OPTS, String.format("%s %s", hadoopOps, hadoopGlobalOps));
+			} else {
+				props.put(HADOOP_OPTS, hadoopGlobalOps);
+			}
+		}
+	}
+
+	@Override
+	protected List<String> getCommandList() {
+		// Use the same parsing login as in default "command job";
+		List<String> commands = super.getCommandList();
+		return HadoopJobUtils.filterCommands(commands, getSysProps().getString(WHITELIST_REGEX, HadoopJobUtils.MATCH_ALL_REGEX), // ".*" will match everything
+				getSysProps().getString(BLACKLIST_REGEX, HadoopJobUtils.MATCH_NONE_REGEX), getLog()); // ".^" will match nothing
+	}
+
+	/**
+	 * This cancel method, in addition to the default canceling behavior, also
+	 * kills the MR jobs launched by this job on Hadoop
+	 */
+	@Override
+	public void cancel() throws InterruptedException {
+		super.cancel();
+
+		info("Cancel called.  Killing the launched Hadoop jobs on the cluster");
+
+		String azExecId = jobProps.getString(CommonJobProperties.EXEC_ID);
+		final String logFilePath = String.format("%s/_job.%s.%s.log", getWorkingDirectory(), azExecId, getId());
+		info("log file path is: " + logFilePath);
+
+		HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(logFilePath, jobProps, tokenFile, getLog());
+	}
+}

--- a/plugins/jobtype/test/azkaban/jobtype/TestHadoopJobUtilsFilterCommands.java
+++ b/plugins/jobtype/test/azkaban/jobtype/TestHadoopJobUtilsFilterCommands.java
@@ -1,0 +1,75 @@
+package jobtype.test.azkaban.jobtype;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.junit.Before;
+import org.junit.Test;
+
+import azkaban.jobtype.HadoopJobUtils;
+import junit.framework.Assert;
+
+/**
+ * Test class for filterCommands method in HadoopJobUtils
+ */
+public class TestHadoopJobUtilsFilterCommands {
+  private Logger logger = Logger.getRootLogger();
+
+  private List<String> originalCommands;
+
+  @Before
+  public void beforeMethod() throws IOException {
+    originalCommands = new LinkedList<String>();
+    originalCommands.add("kinit blah@blah");
+    originalCommands.add("hadoop fs -ls");
+    originalCommands.add("hadoop fs -mkdir");
+    originalCommands.add("kdestroy");
+  }
+
+  @Test
+  public void testEmptyInputList() {
+    List<String> filteredCommands = HadoopJobUtils.filterCommands(Collections.<String> emptyList(),
+            HadoopJobUtils.MATCH_ALL_REGEX, HadoopJobUtils.MATCH_NONE_REGEX, logger);
+    Assert.assertTrue("filtering output of an empty collection should be empty collection",
+            filteredCommands.isEmpty());
+  }
+
+  @Test
+  public void testNoCommandMatchCriteria() {
+    List<String> filteredCommands = HadoopJobUtils.filterCommands(originalCommands, "hadoop.*",
+            "hadoop.*", logger);
+    Assert.assertTrue("filtering output of with no matching command should be empty collection",
+            filteredCommands.isEmpty());
+  }
+
+  @Test
+  public void testWhitelistCriteria() {
+    List<String> filteredCommands = HadoopJobUtils.filterCommands(originalCommands, "hadoop.*",
+            HadoopJobUtils.MATCH_NONE_REGEX, logger);
+    Assert.assertEquals(filteredCommands.get(0), "hadoop fs -ls");
+    Assert.assertEquals(filteredCommands.get(1), "hadoop fs -mkdir");
+  }
+
+  @Test
+  public void testBlackListCriteria() {
+    List<String> filteredCommands = HadoopJobUtils.filterCommands(originalCommands,
+            HadoopJobUtils.MATCH_ALL_REGEX, ".*kinit.*", logger);
+    Assert.assertEquals(filteredCommands.get(0), "hadoop fs -ls");
+    Assert.assertEquals(filteredCommands.get(1), "hadoop fs -mkdir");
+    Assert.assertEquals(filteredCommands.get(2), "kdestroy");
+  }
+
+  @Test
+  public void testMultipleCriterias() {
+    List<String> filteredCommands = HadoopJobUtils.filterCommands(originalCommands, "hadoop.*",
+            ".*kinit.*", logger);
+    Assert.assertEquals(filteredCommands.get(0), "hadoop fs -ls");
+    Assert.assertEquals(filteredCommands.get(1), "hadoop fs -mkdir");
+  }
+}


### PR DESCRIPTION
HadoopShell is a Hadoop security enabled "command" jobtype. This jobtype adheres to same format and other details as "command" jobtype with added functionality to filter commands using a whitelist and blacklist regex and hadoop_opts.