### PR TITLE
Improvement: Reportal skip large attachment #224

### DIFF
--- a/plugins/reportal/src/azkaban/viewer/reportal/ReportalMailCreator.java
+++ b/plugins/reportal/src/azkaban/viewer/reportal/ReportalMailCreator.java
@@ -58,6 +58,7 @@ public class ReportalMailCreator implements MailCreator {
   public static File reportalMailTempDirectory;
   public static final String REPORTAL_MAIL_CREATOR = "ReportalMailCreator";
   public static final int NUM_PREVIEW_ROWS = 50;
+  //Attachment that equal or larger than 10MB will be skipped in the email
   public static final long MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024L;
 
   static {
@@ -352,7 +353,7 @@ public class ReportalMailCreator implements MailCreator {
     message.println("</div>");
     if (totalFileSize >= MAX_ATTACHMENT_SIZE){
       message.println("<tr>Note: Output size >= " + MAX_ATTACHMENT_SIZE/1024/1024 + "MB, " +
-                  "thus not attached in this message. Please use the link on top to download your reports</tr>");
+                  "thus not attached in this message. Please use the link on top to download your reports' output</tr>");
     }
     message.println("</body>").println("</html>");
 

--- a/plugins/reportal/src/azkaban/viewer/reportal/ReportalMailCreator.java
+++ b/plugins/reportal/src/azkaban/viewer/reportal/ReportalMailCreator.java
@@ -352,8 +352,9 @@ public class ReportalMailCreator implements MailCreator {
 
     message.println("</div>");
     if (totalFileSize >= MAX_ATTACHMENT_SIZE){
-      message.println("<tr>Note: Output size >= " + MAX_ATTACHMENT_SIZE/1024/1024 + "MB, " +
-                  "thus not attached in this message. Please use the link on top to download your report's output</tr>");
+      message.println("<tr>The total size of the reports (" + totalFileSize/1024/1024 + "MB) is bigger than the allowed maximum size of " +
+              MAX_ATTACHMENT_SIZE/1024/1024 + "MB. " +
+                  "It is too big to be attached in this message. Please use the link above titled Result Data to download the reports</tr>");
     }
     message.println("</body>").println("</html>");
 

--- a/plugins/reportal/src/azkaban/viewer/reportal/ReportalMailCreator.java
+++ b/plugins/reportal/src/azkaban/viewer/reportal/ReportalMailCreator.java
@@ -353,7 +353,7 @@ public class ReportalMailCreator implements MailCreator {
     message.println("</div>");
     if (totalFileSize >= MAX_ATTACHMENT_SIZE){
       message.println("<tr>Note: Output size >= " + MAX_ATTACHMENT_SIZE/1024/1024 + "MB, " +
-                  "thus not attached in this message. Please use the link on top to download your reports' output</tr>");
+                  "thus not attached in this message. Please use the link on top to download your report's output</tr>");
     }
     message.println("</body>").println("</html>");
 


### PR DESCRIPTION
As discussed with Ray, a hard coded max attachment size of 10MB is good enough for now.