### PR TITLE
security manager's fetched hive token should have a default service f…

### DIFF
--- a/plugins/hadoopsecuritymanager-yarn/src/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/plugins/hadoopsecuritymanager-yarn/src/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -631,8 +631,9 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
         logger.info("Pre-fetching default Hive MetaStore token from hive");
 
         HiveConf hiveConf = new HiveConf();
+        String metastoreUri = hiveConf.get(HiveConf.ConfVars.METASTOREURIS.varname);
         Token<DelegationTokenIdentifier> hcatToken =
-            fetchHcatToken(userToProxy, hiveConf, null, logger);
+            fetchHcatToken(userToProxy, hiveConf, metastoreUri, logger);
 
         cred.addToken(hcatToken.getService(), hcatToken);
 


### PR DESCRIPTION
When hive.obtain.token is set to true, security manager will fetch a hive delegation token. However, by default the delegation token will have an empty service field, and security manager doesn't override this service field. As a result, the hive delegation token with empty service CAN NOT be retrieved later within application master.  We propose a simple fix to always override the token's service field with hive metastore uri conf.