### PR TITLE
Revert "security manager's fetched hive token should have a default service field

### DIFF
--- a/plugins/hadoopsecuritymanager-yarn/src/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/plugins/hadoopsecuritymanager-yarn/src/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -631,9 +631,8 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
         logger.info("Pre-fetching default Hive MetaStore token from hive");
 
         HiveConf hiveConf = new HiveConf();
-        String metastoreUri = hiveConf.get(HiveConf.ConfVars.METASTOREURIS.varname);
         Token<DelegationTokenIdentifier> hcatToken =
-            fetchHcatToken(userToProxy, hiveConf, metastoreUri, logger);
+            fetchHcatToken(userToProxy, hiveConf, null, logger);
 
         cred.addToken(hcatToken.getService(), hcatToken);
 


### PR DESCRIPTION
The previous patch will work for spark job but break hive job type. We need further investigation so please revert it at this time.