### PR TITLE
make reportal compatible with new bootstrap-datetimepicker.js

### DIFF
--- a/plugins/reportal/src/web/js/reportal-edit.js
+++ b/plugins/reportal/src/web/js/reportal-edit.js
@@ -240,5 +240,5 @@ $(document).ready(function () {
   }
   addInitialVariables();
 
-  scheduleDate.datetimepicker({pickTime: false});
+  scheduleDate.datetimepicker({format: 'L'});
 });


### PR DESCRIPTION
This fix is to make reportal compatible with new bootstrap-datetimepicker.js in Azkaban Repo (Detailed in #718 of Azkaban). Since Reportal calls bootstrap-datetimepicker.js in Azkaban Repo, we must make the update.