### PR TITLE
Recognize parameter Hive variables that contain "=" in them (#243)

### DIFF
--- a/plugins/jobtype/src/azkaban/jobtype/HadoopSecureHiveWrapper.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopSecureHiveWrapper.java
@@ -240,20 +240,19 @@ public class HadoopSecureHiveWrapper {
     }
 
     Map<String, String> hiveVarMap = new HashMap<String, String>();
-    int index = 0;
-    for (; index < args.length; index++) {
+    for (int index = 0; index < args.length; index++) {
       if ("-hivevar".equals(args[index])) {
         String hiveVarParam = stripSingleDoubleQuote(args[++index]);
-
-        String[] tokens = hiveVarParam.split("=");
-        if (tokens.length == 2) {
-          String name = tokens[0];
-          String value = tokens[1];
-          logger.info("Setting hivevar: " + name + "=" + value);
-          hiveVarMap.put(name, value);
-        } else {
+        // Separate the parameter string at its first occurence of "="
+        int gap = hiveVarParam.indexOf("=");
+        if (gap == -1) {
           logger.warn("Invalid hivevar: " + hiveVarParam);
+          continue;
         }
+        String name = hiveVarParam.substring(0, gap);
+        String value = hiveVarParam.substring(gap + 1);
+        logger.info("Setting hivevar: " + name + "=" + value);
+        hiveVarMap.put(name, value);
       }
     }
     return hiveVarMap;

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopSecureHiveWrapper.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopSecureHiveWrapper.java
@@ -203,9 +203,9 @@ public class HadoopSecureHiveWrapper {
   /**
    * Extract hiveconf from command line arguments and populate them into
    * HiveConf
-   * 
+   *
    * An example: -hiveconf 'zipcode=10', -hiveconf hive.root.logger=INFO,console
-   * 
+   *
    * @param hiveConf
    * @param args
    */
@@ -233,7 +233,7 @@ public class HadoopSecureHiveWrapper {
     }
   }
 
-  private static Map<String, String> getHiveVarMap(String[] args) {
+  static Map<String, String> getHiveVarMap(String[] args) {
 
     if (args == null) {
       return Collections.emptyMap();
@@ -260,7 +260,7 @@ public class HadoopSecureHiveWrapper {
 
   /**
    * Strip single quote or double quote at either end of the string
-   * 
+   *
    * @param input
    * @return string with w/o leading or trailing single or double quote
    */

--- a/plugins/jobtype/test/azkaban/jobtype/TestHadoopSecureHiveWrapper.java
+++ b/plugins/jobtype/test/azkaban/jobtype/TestHadoopSecureHiveWrapper.java
@@ -1,0 +1,23 @@
+package azkaban.jobtype;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestHadoopSecureHiveWrapper {
+  // Ensure that hivevars with equal signs in them are parsed
+  // properly, as the string may be split incorrectly around them.
+  @Test
+  public void testParamsWithEqualSigns() {
+    String[] args = {"-hivevar", "'testKey1=testVal1'",
+        "-hivevar", "'testKey2=testVal2==something=anything'",
+        "-hivevar", "'testKey3=testVal3=anything'"};
+    Map<String, String> hiveVarMap = HadoopSecureHiveWrapper.getHiveVarMap(args);
+    Assert.assertTrue(hiveVarMap.size() == 3);
+    Assert.assertTrue(hiveVarMap.get("testKey1").equals("testVal1"));
+    Assert.assertTrue(hiveVarMap.get("testKey2").equals("testVal2==something=anything"));
+    Assert.assertTrue(hiveVarMap.get("testKey3").equals("testVal3=anything"));
+  }
+}
+


### PR DESCRIPTION
Hive parameter parser would throw out parameters that contain more than
one equal sign. Hence, if we pass a SQL query to Hive that contains an
equal sign, the Hive plugin would take it as invalid, even though it's a
fine variable value.