### PR TITLE
Tez session not being closed

### DIFF
--- a/plugins/jobtype/src/azkaban/jobtype/HadoopSecureHiveWrapper.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopSecureHiveWrapper.java
@@ -157,22 +157,20 @@ public class HadoopSecureHiveWrapper {
       cli.setHiveVariables(getHiveVarMap(args));
     }
 
-	int returnCode = 0;
-	try {
-		returnCode = cli.processFile(hiveScript);
-	} catch (Exception ex) {
-		logger.error("Error processing file: ", ex);
+    int returnCode = 0;
+    try {
+        returnCode = cli.processFile(hiveScript);
+    } catch (Exception ex) {
+        logger.error("Error processing file: ", ex);
+    } finally {
+        logger.info("Closing session state.");
+        if (ss != null)
+            ss.close();
+    }
 
-	} finally {
-		logger.info("Closing session state.");
-
-		if (ss != null)
-			ss.close();
-	}
-
-	if (returnCode != 0) {
-		logger.warn("Got exception " + returnCode + " from line: " + hiveScript);
-		throw new HiveQueryExecutionException(returnCode, hiveScript);
+    if (returnCode != 0) {
+        logger.warn("Got exception " + returnCode + " from line: " + hiveScript);
+        throw new HiveQueryExecutionException(returnCode, hiveScript);
     }  
 	
   }

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopSecureHiveWrapper.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopSecureHiveWrapper.java
@@ -157,11 +157,24 @@ public class HadoopSecureHiveWrapper {
       cli.setHiveVariables(getHiveVarMap(args));
     }
 
-    int returnCode = cli.processFile(hiveScript);
-    if (returnCode != 0) {
-      logger.warn("Got exception " + returnCode + " from line: " + hiveScript);
-      throw new HiveQueryExecutionException(returnCode, hiveScript);
-    }
+	int returnCode = 0;
+	try {
+		returnCode = cli.processFile(hiveScript);
+	} catch (Exception ex) {
+		logger.error("Error processing file: ", ex);
+
+	} finally {
+		logger.info("Closing session state.");
+
+		if (ss != null)
+			ss.close();
+	}
+
+	if (returnCode != 0) {
+		logger.warn("Got exception " + returnCode + " from line: " + hiveScript);
+		throw new HiveQueryExecutionException(returnCode, hiveScript);
+    }  
+	
   }
 
   /**


### PR DESCRIPTION
Hive session is not being closed. This is not a problem when using mapreduce.
When using tez, AM sessions keep running until tez timeout expires.

Hive SessionState should be closed.