### PR TITLE
Spark Azkaban Jobtype changes to enable version-aware queue enforcement

### DIFF
--- a/plugins/jobtype/src/azkaban/jobtype/HadoopSecureSparkWrapper.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopSecureSparkWrapper.java
@@ -18,6 +18,7 @@ package azkaban.jobtype;
 
 import azkaban.utils.Props;
 import com.google.common.collect.Maps;
+
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,6 +27,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -312,17 +314,6 @@ public class HadoopSecureSparkWrapper {
 
     if (nodeLabelingYarn && nodeLabelingPolicy) {
       ignoreUserSpecifiedNodeLabelParameter(argArray, autoNodeLabeling);
-
-      // If yarn cluster enables node labelling, applications should be submitted to a default
-      // queue by a default conf(spark.yarn.queue) in spark-defaults.conf.
-      int queueParameterIndex = getUserSpecifiedQueueParameterIndex(argArray);
-      if (queueParameterIndex != -1) {
-        logger.info(
-            "Azbakan enforces node labeling. Ignore user param: " + argArray[queueParameterIndex] + " " + argArray[
-                queueParameterIndex + 1]);
-        argArray[queueParameterIndex] = null;
-        argArray[queueParameterIndex + 1] = null;
-      }
 
       // If auto node labeling is enabled, automatically sets spark.yarn.executor.nodeLabelExpression
       // config based on user requested resources.

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopSecureSparkWrapper.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopSecureSparkWrapper.java
@@ -16,17 +16,12 @@
 
 package azkaban.jobtype;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.lang.reflect.Field;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 import org.apache.commons.lang.math.NumberUtils;
@@ -38,7 +33,6 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.util.Utils;
 
-import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.utils.Props;
 import static azkaban.flow.CommonJobProperties.ATTEMPT_LINK;
 import static azkaban.flow.CommonJobProperties.EXECUTION_LINK;
@@ -79,6 +73,7 @@ public class HadoopSecureSparkWrapper {
 
   //YARN CONF PARAM
   private static final String YARN_CONF_NODE_LABELING_ENABLED = "yarn.node-labels.enabled";
+  public static final String DEFAULT_QUEUE = "default";
 
   /**
    * Entry point: a Java wrapper to the spark-submit command
@@ -137,7 +132,7 @@ public class HadoopSecureSparkWrapper {
     handleDriverJavaOpts(newArgs);
 
     // If dynamic allocation policy for this jobtype is turned on, adjust related param
-    handleDynamicResourceAllocation(newArgs);
+    newArgs = handleDynamicResourceAllocation(newArgs);
 
     // If yarn cluster enables node labeling, adjust related param
     newArgs = handleNodeLabeling(newArgs);
@@ -174,7 +169,7 @@ public class HadoopSecureSparkWrapper {
     argArray[1] = driverJavaOptions.toString();
   }
 
-  private static void handleDynamicResourceAllocation(String[] argArray) {
+  private static String[] handleDynamicResourceAllocation(String[] argArray) {
     // HadoopSparkJob will set env var on this process if we enforce dynamic allocation policy for spark jobtype.
     // This policy can be enabled through spark jobtype plugin's conf property.
     // Enabling dynamic allocation policy for azkaban spark jobtype is different from enabling dynamic allocation
@@ -200,7 +195,121 @@ public class HadoopSecureSparkWrapper {
           argArray[++i] = null;
         }
       }
+      // If dynamic allocation is enabled, make sure application is scheduled in right queue
+      argArray = handleQueueEnforcement(argArray);
     }
+    return argArray;
+  }
+
+  /**
+   * This method is used to enforce queue for Spark application. Rules are explained below.
+   * a) If dynamic resource allocation is enabled for selected spark version and application requires large container
+   *    then schedule it into default queue by a default conf(spark.yarn.queue) in spark-defaults.conf.
+   * b) If dynamic resource allocation is enabled for selected spark version and application requires small container
+   *    then schedule it into Org specific queue.
+   * c) If dynamic resource allocation is disabled for selected spark version then schedule application into default
+   *    queue by a default conf(spark.yarn.queue) in spark-defaults.conf.
+   * @param argArray
+   * @return
+   */
+  protected static String[] handleQueueEnforcement(String[] argArray) {
+    SparkConf sparkConf = getSparkProperties();
+    Configuration conf = new Configuration();
+    String executorMem = null;
+    String executorVcore = null;
+    String executorMemOverhead = null;
+    int queueParameterIndex = -1;
+    for (int i = 0; i < argArray.length; ++i) {
+      if (argArray[i] != null) {
+        if (argArray[i].equals(SparkJobArg.EXECUTOR_CORES.sparkParamName)) {
+          executorVcore = argArray[++i];
+        }
+        if (argArray[i].equals(SparkJobArg.EXECUTOR_MEMORY.sparkParamName)) {
+          executorMem = argArray[++i];
+        }
+        if (argArray[i].equals(SparkJobArg.SPARK_CONF_PREFIX.sparkParamName) && argArray[i + 1]
+            .startsWith(SPARK_EXECUTOR_MEMORY_OVERHEAD)) {
+          executorMemOverhead = argArray[i + 1].split("=")[1].trim();
+        }
+
+        if (argArray[i].equals(SparkJobArg.SPARK_CONF_PREFIX.sparkParamName) && argArray[i + 1]
+            .startsWith(SPARK_CONF_QUEUE) || argArray[i].equals(SparkJobArg.QUEUE.sparkParamName)) {
+          queueParameterIndex = i;
+        }
+      }
+    }
+
+    boolean requiredSparkDefaultQueue = false;
+    if (sparkConf.getBoolean(SPARK_CONF_DYNAMIC_ALLOC_ENABLED, false)) {
+      if (isLargeContainerRequired(executorVcore, executorMem, executorMemOverhead, conf, sparkConf)) {
+        // Case A
+        requiredSparkDefaultQueue = true;
+        logger.info(
+            "Spark application requires Large containers. Scheduling this application into default queue by a "
+                + "default conf(spark.yarn.queue) in spark-defaults.conf.");
+      } else {
+        // Case B
+        logger.info(
+            "Dynamic allocation is enabled for selected spark version and application requires small container. "
+                + "Hence, scheduling this application into Org specific queue");
+        if(queueParameterIndex == -1) {
+          LinkedList<String> argList = new LinkedList(Arrays.asList(argArray));
+          argList.addFirst(SPARK_CONF_QUEUE + "=" + DEFAULT_QUEUE);
+          argList.addFirst(SparkJobArg.SPARK_CONF_PREFIX.sparkParamName);
+          argArray = argList.toArray(new String[argList.size()]);
+        }
+      }
+    } else {
+      // Case C
+      logger.info(
+          "Spark version, selected for this application, doesn't support dynamic allocation. Scheduling this "
+              + "application into default queue by a default conf(spark.yarn.queue) in spark-defaults.conf.");
+      requiredSparkDefaultQueue = true;
+    }
+
+    if (queueParameterIndex != -1 && requiredSparkDefaultQueue) {
+      logger.info("Azbakan enforces spark.yarn.queue queue. Ignore user param: " + argArray[queueParameterIndex] + " "
+          + argArray[queueParameterIndex + 1]);
+      argArray[queueParameterIndex] = null;
+      argArray[queueParameterIndex + 1] = null;
+    }
+    return argArray;
+  }
+
+  /**
+   * This method is used to check whether large container is required for application or not.
+   * To decide that, it is using parameters like
+   * User Job parameters/default value for : spark.executor.cores, spark.executor.memory, spark.yarn.executor.memoryOverhead
+   * Jobtype Plugin parameters: spark.min.mem.vore.ratio, spark.min.memory-gb.size
+   * If rounded memory / spark.executor.cores >= spark.min.mem.vore.ratio or rounded memory >= spark.min.memory-gb.size
+   * then large container is required to schedule this application.
+   * @param executorVcore
+   * @param executorMem
+   * @param executorMemOverhead
+   * @param conf
+   * @param sparkConf
+   * @return
+   */
+  private static boolean isLargeContainerRequired(String executorVcore, String executorMem, String executorMemOverhead,
+      Configuration conf, SparkConf sparkConf) {
+    if (executorVcore == null) {
+      executorVcore = sparkConf.get(SPARK_EXECUTOR_CORES, SPARK_EXECUTOR_DEFAULT_CORES);
+    }
+    if (executorMem == null) {
+      executorMem = sparkConf.get(SPARK_EXECUTOR_MEMORY, SPARK_EXECUTOR_DEFAULT_MEMORY);
+    }
+    if (executorMemOverhead == null) {
+      executorMemOverhead = sparkConf.get(SPARK_EXECUTOR_MEMORY_OVERHEAD, null);
+    }
+
+    double roundedMemoryGbSize = getRoundedMemoryGb(executorMem, executorMemOverhead, conf);
+
+    double minRatio = Double.parseDouble(System.getenv(HadoopSparkJob.SPARK_MIN_MEM_VCORE_RATIO_ENV_VAR));
+    double minMemSize = Double.parseDouble(System.getenv(HadoopSparkJob.SPARK_MIN_MEM_SIZE_ENV_VAR));
+
+    logger.info("RoundedMemoryGbSize: " + roundedMemoryGbSize + ", ExecutorVcore: " + executorVcore + ", MinRatio: " + minRatio + ", MinMemSize: " + minMemSize);
+    return roundedMemoryGbSize / (double) Integer.parseInt(executorVcore) >= minRatio
+        || roundedMemoryGbSize >= minMemSize;
   }
 
   protected static String[] handleNodeLabeling(String[] argArray) {
@@ -210,22 +319,17 @@ public class HadoopSecureSparkWrapper {
     // feature for Yarn. This config inside Spark job type is to enforce node labeling feature for all
     // Spark applications submitted via Azkaban Spark job type.
     Configuration conf = new Configuration();
-    String sparkPropertyFile = HadoopSecureSparkWrapper.class.getClassLoader()
-        .getResource("spark-defaults.conf").getPath();
     boolean nodeLabelingYarn = conf.getBoolean(YARN_CONF_NODE_LABELING_ENABLED, false);
     String nodeLabelingProp = System.getenv(HadoopSparkJob.SPARK_NODE_LABELING_ENV_VAR);
     boolean nodeLabelingPolicy = nodeLabelingProp != null && nodeLabelingProp.equals(Boolean.TRUE.toString());
     String autoNodeLabelProp = System.getenv(HadoopSparkJob.SPARK_AUTO_NODE_LABELING_ENV_VAR);
     boolean autoNodeLabeling = autoNodeLabelProp != null && autoNodeLabelProp.equals(Boolean.TRUE.toString());
     String desiredNodeLabel = System.getenv(HadoopSparkJob.SPARK_DESIRED_NODE_LABEL_ENV_VAR);
-    String minMemVcoreRatio = System.getenv(HadoopSparkJob.SPARK_MIN_MEM_VCORE_RATIO_ENV_VAR);
-    String minMemGBSize = System.getenv(HadoopSparkJob.SPARK_MIN_MEM_SIZE_ENV_VAR);
     String executorMem = null;
     String executorVcore = null;
     String executorMemOverhead = null;
 
-    SparkConf sparkConf = new SparkConf(false);
-    sparkConf.setAll(Utils.getPropertiesFromFile(sparkPropertyFile));
+    SparkConf sparkConf = getSparkProperties();
 
     if (nodeLabelingYarn && nodeLabelingPolicy) {
       for (int i = 0; i < argArray.length; i++) {
@@ -276,20 +380,7 @@ public class HadoopSecureSparkWrapper {
       // If auto node labeling is enabled, automatically sets spark.yarn.executor.nodeLabelExpression
       // config based on user requested resources.
       if (autoNodeLabeling) {
-        double minRatio = Double.parseDouble(minMemVcoreRatio);
-        double minMemSize = Double.parseDouble(minMemGBSize);
-        if (executorVcore == null) {
-          executorVcore = sparkConf.get(SPARK_EXECUTOR_CORES, SPARK_EXECUTOR_DEFAULT_CORES);
-        }
-        if (executorMem == null) {
-          executorMem = sparkConf.get(SPARK_EXECUTOR_MEMORY, SPARK_EXECUTOR_DEFAULT_MEMORY);
-        }
-        if (executorMemOverhead == null) {
-          executorMemOverhead = sparkConf.get(SPARK_EXECUTOR_MEMORY_OVERHEAD, null);
-        }
-        double roundedMemoryGbSize = getRoundedMemoryGb(executorMem, executorMemOverhead, conf);
-        if (roundedMemoryGbSize / Integer.parseInt(executorVcore) >= minRatio ||
-            roundedMemoryGbSize >= minMemSize) {
+        if (isLargeContainerRequired(executorVcore, executorMem, executorMemOverhead, conf, sparkConf)) {
           LinkedList<String> argList = new LinkedList<String>(Arrays.asList(argArray));
           argList.addFirst(SPARK_EXECUTOR_NODE_LABEL_EXP + "=" + desiredNodeLabel);
           argList.addFirst(SparkJobArg.SPARK_CONF_PREFIX.sparkParamName);
@@ -298,6 +389,18 @@ public class HadoopSecureSparkWrapper {
       }
     }
     return argArray;
+  }
+
+  /**
+   * This method is used to get Spark properties which will fetch properties from spark-defaults.conf file.
+   * @return
+   */
+  private static SparkConf getSparkProperties() {
+    String sparkPropertyFile = HadoopSecureSparkWrapper.class.getClassLoader()
+        .getResource("spark-defaults.conf").getPath();
+    SparkConf sparkConf = new SparkConf(false);
+    sparkConf.setAll(Utils.getPropertiesFromFile(sparkPropertyFile));
+    return sparkConf;
   }
 
   /**

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopSparkJob.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopSparkJob.java
@@ -66,12 +66,18 @@ import azkaban.utils.StringUtils;
  *             Conf will be either SPARK_CONF_DIR(we do not override it) or {spark.home}/conf
  *
  * spark.1.6.0.home (spark.{version}.home is REQUIRED for the {version} that we want to support.
- *                  e.g. user can use spark 1.6.0 by setting spark.home=1.6.0 in their job property.
+ *                  e.g. user can use spark 1.6.0 by setting spark.version=1.6.0 in their job property.
  *                  This class will then look for plugin property spark.1.6.0.home to get the proper spark
  *                  bin/conf to launch the client)
  *
  * spark.1.6.0.conf (OPTIONAL. spark.{version}.conf is the conf used for the {version}.
  *                  If not specified, the conf of this {version} will be spark.{version}.home/conf
+ *
+ * spark.home.dir To reduce dependency on azkban-jobtype plugin properties every time new spark binary is available,
+ *                this property needs to be set. It specifies path where spark binaries are kept.
+ *                If spark.{sparkVersion}.home is set in commonprivate.properties/private.properties,
+ *                then that will be returned. If spark.{sparkVersion}.home is not set and spark.home.dir is set then
+ *                it will retrieve Spark directory inside spark.home.dir, matching spark.home.prefix + sparkVersion pattern.
  *
  * spark.dynamic.res.alloc.enforced (set to true if we want to enforce dynamic resource allocation policy.
  *                  Enabling dynamic allocation policy for spark job type is different from enabling dynamic
@@ -192,7 +198,25 @@ public class HadoopSparkJob extends JavaProcessJob {
     // then set proper env var for client wrapper(HadoopSecureSparkWrapper) to modify spark job conf
     // before calling spark-submit to enforce every spark job uses dynamic allocation or node labeling
     if (getSysProps().getBoolean(SPARK_DYNAMIC_RES_JOBTYPE_PROPERTY, Boolean.FALSE)) {
+      String minMemVcoreRatio = getSysProps().get(SPARK_MIN_MEM_VCORE_RATIO_JOBTYPE_PROPERTY);
+      String minMemSize = getSysProps().get(SPARK_MIN_MEM_SIZE_JOBTYPE_PROPERTY);
+      if (minMemVcoreRatio == null
+          || minMemSize == null) {
+        throw new RuntimeException(SPARK_MIN_MEM_SIZE_JOBTYPE_PROPERTY + " and " +
+            SPARK_MIN_MEM_VCORE_RATIO_JOBTYPE_PROPERTY + " must be configured when " +
+            SPARK_DYNAMIC_RES_JOBTYPE_PROPERTY + " is set to true.");
+      }
+      if (!NumberUtils.isNumber(minMemVcoreRatio)) {
+        throw new RuntimeException(SPARK_MIN_MEM_VCORE_RATIO_JOBTYPE_PROPERTY + " is configured as " +
+            minMemVcoreRatio + ", but it must be a number.");
+      }
+      if (!NumberUtils.isNumber(minMemSize)) {
+        throw new RuntimeException(SPARK_MIN_MEM_SIZE_JOBTYPE_PROPERTY + " is configured as " +
+            minMemSize + ", but it must be a number.");
+      }
       getJobProps().put("env." + SPARK_DYNAMIC_RES_ENV_VAR, Boolean.TRUE.toString());
+      getJobProps().put("env." + SPARK_MIN_MEM_VCORE_RATIO_ENV_VAR, minMemVcoreRatio);
+      getJobProps().put("env." + SPARK_MIN_MEM_SIZE_ENV_VAR, minMemSize);
     }
 
     if (getSysProps().getBoolean(SPARK_NODE_LABELING_JOBTYPE_PROPERTY, Boolean.FALSE)) {

--- a/plugins/jobtype/test/azkaban/jobtype/TestHadoopSecureSparkWrapper.java
+++ b/plugins/jobtype/test/azkaban/jobtype/TestHadoopSecureSparkWrapper.java
@@ -16,8 +16,12 @@
 
 package azkaban.jobtype;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
-import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
@@ -44,6 +48,7 @@ public class TestHadoopSecureSparkWrapper {
     envs.put(HadoopSparkJob.SPARK_MIN_MEM_VCORE_RATIO_ENV_VAR, "3");
     envs.put(HadoopSparkJob.SPARK_MIN_MEM_SIZE_ENV_VAR, "8");
     setEnv(envs);
+    setSparkDefaultsConf();
     Configuration.addDefaultResource("yarn-site.xml");
     String[] argArray = new String[] {
         "--conf",
@@ -70,6 +75,7 @@ public class TestHadoopSecureSparkWrapper {
     envs.put(HadoopSparkJob.SPARK_DESIRED_NODE_LABEL_ENV_VAR, "test2");
     envs.put(HadoopSparkJob.SPARK_MIN_MEM_VCORE_RATIO_ENV_VAR, "3");
     setEnv(envs);
+    setSparkDefaultsConf();
     Configuration.addDefaultResource("yarn-site.xml");
     String[] argArray = new String[] {
         "--conf",
@@ -98,6 +104,7 @@ public class TestHadoopSecureSparkWrapper {
     envs.put(HadoopSparkJob.SPARK_MIN_MEM_VCORE_RATIO_ENV_VAR, "3");
     envs.put(HadoopSparkJob.SPARK_MIN_MEM_SIZE_ENV_VAR, "6");
     setEnv(envs);
+    setSparkDefaultsConf();
     Configuration.addDefaultResource("yarn-site.xml");
     String[] argArray = new String[] {
         "--conf",
@@ -112,6 +119,96 @@ public class TestHadoopSecureSparkWrapper {
   }
 
   @Test
+  public void testQueueEnforcementForDisabledDynamicResAllocation() {
+    Map<String, String> envs = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
+    envs.put(HadoopSparkJob.SPARK_DYNAMIC_RES_ENV_VAR, Boolean.TRUE.toString());
+    setEnv(envs);
+    setSparkDefaultsConf();
+    Configuration.addDefaultResource("yarn-site.xml");
+    String[] argArray = new String[] {
+        "--conf",
+        "spark.yarn.queue=test",
+        "--conf",
+        "--executor-cores",
+        "3",
+        "--executor-memory",
+        "7G"
+    };
+    argArray = HadoopSecureSparkWrapper.handleQueueEnforcement(argArray);
+    argArray = HadoopSecureSparkWrapper.removeNullsFromArgArray(argArray);
+    Assert.assertTrue(argArray.length == 5);
+  }
+
+  @Test
+  public void testQueueEnforcementForSmallContainer() {
+    Map<String, String> envs = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
+    envs.put(HadoopSparkJob.SPARK_DYNAMIC_RES_ENV_VAR, Boolean.TRUE.toString());
+    envs.put(HadoopSparkJob.SPARK_MIN_MEM_VCORE_RATIO_ENV_VAR, "4");
+    envs.put(HadoopSparkJob.SPARK_MIN_MEM_SIZE_ENV_VAR, "8");
+    setEnv(envs);
+    setSparkDefaultsConf("queue-enforcement-spark-defaults.conf");
+    Configuration.addDefaultResource("yarn-site.xml");
+    String[] argArray = new String[] {
+        "--conf",
+        "--executor-cores",
+        "1",
+        "--executor-memory",
+        "2G"
+    };
+    argArray = HadoopSecureSparkWrapper.handleQueueEnforcement(argArray);
+    argArray = HadoopSecureSparkWrapper.removeNullsFromArgArray(argArray);
+    Assert.assertTrue(argArray.length == 7);
+    Assert.assertTrue(argArray[1].contains("default"));
+  }
+
+  @Test
+  public void testUserQueueSpecifiedForSmallContainer() {
+    Map<String, String> envs = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
+    envs.put(HadoopSparkJob.SPARK_DYNAMIC_RES_ENV_VAR, Boolean.TRUE.toString());
+    envs.put(HadoopSparkJob.SPARK_MIN_MEM_VCORE_RATIO_ENV_VAR, "4");
+    envs.put(HadoopSparkJob.SPARK_MIN_MEM_SIZE_ENV_VAR, "8");
+    setEnv(envs);
+    setSparkDefaultsConf("queue-enforcement-spark-defaults.conf");
+    Configuration.addDefaultResource("yarn-site.xml");
+    String[] argArray = new String[] {
+        "--conf",
+        "spark.yarn.queue=test",
+        "--conf",
+        "--executor-cores",
+        "1",
+        "--executor-memory",
+        "2G"
+    };
+    argArray = HadoopSecureSparkWrapper.handleQueueEnforcement(argArray);
+    argArray = HadoopSecureSparkWrapper.removeNullsFromArgArray(argArray);
+    Assert.assertTrue(argArray.length == 7);
+    Assert.assertTrue(argArray[1].contains("test"));
+  }
+
+  @Test
+  public void testQueueEnforcementForLargeContainer() {
+    Map<String, String> envs = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
+    envs.put(HadoopSparkJob.SPARK_DYNAMIC_RES_ENV_VAR, Boolean.TRUE.toString());
+    envs.put(HadoopSparkJob.SPARK_MIN_MEM_VCORE_RATIO_ENV_VAR, "4");
+    envs.put(HadoopSparkJob.SPARK_MIN_MEM_SIZE_ENV_VAR, "8");
+    setEnv(envs);
+    setSparkDefaultsConf("queue-enforcement-spark-defaults.conf");
+    Configuration.addDefaultResource("yarn-site.xml");
+    String[] argArray = new String[] {
+        "--conf",
+        "spark.yarn.queue=test",
+        "--conf",
+        "--executor-cores",
+        "3",
+        "--executor-memory",
+        "20G"
+    };
+    argArray = HadoopSecureSparkWrapper.handleQueueEnforcement(argArray);
+    argArray = HadoopSecureSparkWrapper.removeNullsFromArgArray(argArray);
+    Assert.assertTrue(argArray.length == 5);
+  }
+
+  @Test
   public void testAutoLabelingWithMemSizeExceedingLimit() {
     // When user requested executor container memory size exceeds spark.min.memory-gb.size,
     // even if the ratio is still below the threshold, the job should still be submitted
@@ -123,6 +220,7 @@ public class TestHadoopSecureSparkWrapper {
     envs.put(HadoopSparkJob.SPARK_MIN_MEM_VCORE_RATIO_ENV_VAR, "4");
     envs.put(HadoopSparkJob.SPARK_MIN_MEM_SIZE_ENV_VAR, "5");
     setEnv(envs);
+    setSparkDefaultsConf();
     Configuration.addDefaultResource("yarn-site.xml");
     String[] argArray = new String[] {
         "--conf",
@@ -140,6 +238,17 @@ public class TestHadoopSecureSparkWrapper {
     Assert.assertTrue(argArray[1].contains("test2"));
   }
 
+  @SuppressWarnings("unchecked")
+  private static void setSparkDefaultsConf(String... sourcePath) {
+    String sourceFile = sourcePath.length == 0 ? "common-spark-defaults.conf" : sourcePath[0];
+    Path source = Paths.get("test_resource/" + sourceFile);
+    Path target = Paths.get("test_resource/spark-defaults.conf");
+    try {
+      Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+    } catch (IOException e) {
+      logger.error(e);
+    }
+  }
   @SuppressWarnings("unchecked")
   private static void setEnv(Map<String, String> newenv) {
     try

--- a/plugins/jobtype/test/azkaban/jobtype/TestHadoopSecureSparkWrapper.java
+++ b/plugins/jobtype/test/azkaban/jobtype/TestHadoopSecureSparkWrapper.java
@@ -62,7 +62,7 @@ public class TestHadoopSecureSparkWrapper {
     };
     argArray = HadoopSecureSparkWrapper.handleNodeLabeling(argArray);
     argArray = HadoopSecureSparkWrapper.removeNullsFromArgArray(argArray);
-    Assert.assertTrue(argArray.length == 6);
+    Assert.assertTrue(argArray.length == 8);
     Assert.assertTrue(argArray[1].contains("test2"));
   }
 
@@ -89,7 +89,7 @@ public class TestHadoopSecureSparkWrapper {
     };
     argArray = HadoopSecureSparkWrapper.handleNodeLabeling(argArray);
     argArray = HadoopSecureSparkWrapper.removeNullsFromArgArray(argArray);
-    Assert.assertTrue(argArray.length == 6);
+    Assert.assertTrue(argArray.length == 8);
     Assert.assertTrue(argArray[1].contains("test"));
   }
 
@@ -114,7 +114,7 @@ public class TestHadoopSecureSparkWrapper {
     };
     argArray = HadoopSecureSparkWrapper.handleNodeLabeling(argArray);
     argArray = HadoopSecureSparkWrapper.removeNullsFromArgArray(argArray);
-    Assert.assertTrue(argArray.length == 2);
+    Assert.assertTrue(argArray.length == 4);
     Assert.assertTrue(argArray[1].contains("test2"));
   }
 
@@ -234,7 +234,7 @@ public class TestHadoopSecureSparkWrapper {
     };
     argArray = HadoopSecureSparkWrapper.handleNodeLabeling(argArray);
     argArray = HadoopSecureSparkWrapper.removeNullsFromArgArray(argArray);
-    Assert.assertTrue(argArray.length == 6);
+    Assert.assertTrue(argArray.length == 8);
     Assert.assertTrue(argArray[1].contains("test2"));
   }
 

--- a/test_resource/common-spark-defaults.conf
+++ b/test_resource/common-spark-defaults.conf
@@ -1,3 +1,4 @@
 spark.executor.memory = 4G
 spark.executor.cores = 1
 spark.yarn.executor.memoryOverhead = 128
+spark.yarn.queue = hightest

--- a/test_resource/queue-enforcement-spark-defaults.conf
+++ b/test_resource/queue-enforcement-spark-defaults.conf
@@ -1,0 +1,5 @@
+spark.executor.memory = 4G
+spark.executor.cores = 1
+spark.yarn.executor.memoryOverhead = 128
+spark.yarn.queue = hightest
+spark.dynamicAllocation.enabled = true


### PR DESCRIPTION
Currently there is no queue enforcement for Spark jobs. As we start using dynamic allocation feature of Spark, we can push Spark jobs to Org specific queues. I have mentioned all cases of queue enforcement below.

- If dynamic resource allocation is enabled for selected spark version and application requires large container then schedule it into default queue by a default conf(spark.yarn.queue) in spark-defaults.conf.

- If dynamic resource allocation is enabled for selected spark version and application requires small container then schedule it into Org specific queue if user has not provided queue. If user has provided queue then use that.

- If dynamic resource allocation is disabled for selected spark version then schedule application into default queue by a default conf(spark.yarn.queue) in spark-defaults.conf.