### PR TITLE
Modify job types to respect additional namenode delegation token configs

### DIFF
--- a/plugins/jobtype/src/azkaban/jobtype/HadoopHiveJob.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopHiveJob.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
 
@@ -92,11 +91,7 @@ public class HadoopHiveJob extends JavaProcessJob {
       Props props = new Props();
       props.putAll(getJobProps());
       props.putAll(getSysProps());
-      String additionalNamenodes =
-          (new Configuration()).get(HadoopJobUtils.MAPREDUCE_JOB_OTHER_NAMENODES);
-      if (additionalNamenodes != null && additionalNamenodes.length() > 0) {
-        HadoopJobUtils.addAdditionalNamenodesToProps(props, additionalNamenodes);
-      }
+      HadoopJobUtils.addAdditionalNamenodesToPropsFromMRJob(props, getLog());
       tokenFile = HadoopJobUtils.getHadoopTokens(hadoopSecurityManager, props, getLog());
       getJobProps().put("env." + HADOOP_TOKEN_FILE_LOCATION,
           tokenFile.getAbsolutePath());

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopHiveJob.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopHiveJob.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
 
@@ -91,6 +92,11 @@ public class HadoopHiveJob extends JavaProcessJob {
       Props props = new Props();
       props.putAll(getJobProps());
       props.putAll(getSysProps());
+      String additionalNamenodes =
+          (new Configuration()).get(HadoopJobUtils.MAPREDUCE_JOB_OTHER_NAMENODES);
+      if (additionalNamenodes != null && additionalNamenodes.length() > 0) {
+        HadoopJobUtils.addAdditionalNamenodesToProps(props, additionalNamenodes);
+      }
       tokenFile = HadoopJobUtils.getHadoopTokens(hadoopSecurityManager, props, getLog());
       getJobProps().put("env." + HADOOP_TOKEN_FILE_LOCATION,
           tokenFile.getAbsolutePath());

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopJavaJob.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopJavaJob.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
 
@@ -178,6 +179,11 @@ public class HadoopJavaJob extends JavaProcessJob {
       props.putAll(getJobProps());
       props.putAll(getSysProps());
 
+      String additionalNamenodes =
+          (new Configuration()).get(HadoopJobUtils.MAPREDUCE_JOB_OTHER_NAMENODES);
+      if (additionalNamenodes != null && additionalNamenodes.length() > 0) {
+        HadoopJobUtils.addAdditionalNamenodesToProps(props, additionalNamenodes);
+      }
       tokenFile =
           HadoopJobUtils
               .getHadoopTokens(hadoopSecurityManager, props, getLog());

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopJavaJob.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopJavaJob.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
 
@@ -179,11 +178,7 @@ public class HadoopJavaJob extends JavaProcessJob {
       props.putAll(getJobProps());
       props.putAll(getSysProps());
 
-      String additionalNamenodes =
-          (new Configuration()).get(HadoopJobUtils.MAPREDUCE_JOB_OTHER_NAMENODES);
-      if (additionalNamenodes != null && additionalNamenodes.length() > 0) {
-        HadoopJobUtils.addAdditionalNamenodesToProps(props, additionalNamenodes);
-      }
+      HadoopJobUtils.addAdditionalNamenodesToPropsFromMRJob(props, getLog());
       tokenFile =
           HadoopJobUtils
               .getHadoopTokens(hadoopSecurityManager, props, getLog());

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopJobUtils.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopJobUtils.java
@@ -147,6 +147,24 @@ public class HadoopJobUtils {
   }
 
   /**
+   * The same as {@link #addAdditionalNamenodesToProps}, but assumes that the
+   * calling job is MapReduce-based and so uses the
+   * {@link #MAPREDUCE_JOB_OTHER_NAMENODES} from a {@link Configuration} object
+   * to get the list of additional namenodes.
+   * @param props Props to add the new Namenode URIs to.
+   * @see #addAdditionalNamenodesToProps(Props, String)
+   */
+  public static void addAdditionalNamenodesToPropsFromMRJob(Props props, Logger log) {
+    String additionalNamenodes =
+        (new Configuration()).get(MAPREDUCE_JOB_OTHER_NAMENODES);
+    if (additionalNamenodes != null && additionalNamenodes.length() > 0) {
+      log.info("Found property " + MAPREDUCE_JOB_OTHER_NAMENODES +
+          " = " + additionalNamenodes + "; setting additional namenodes");
+      HadoopJobUtils.addAdditionalNamenodesToProps(props, additionalNamenodes);
+    }
+  }
+
+  /**
    * Takes the list of other Namenodes from which to fetch delegation tokens,
    * the {@link #OTHER_NAMENODES_PROPERTY} property, from Props and inserts it
    * back with the addition of the the potentially JobType-specific Namenode URIs

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopJobUtils.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopJobUtils.java
@@ -85,6 +85,12 @@ public class HadoopJobUtils {
   // Azkaban built in property name
   public static final String JVM_ARGS = "jvm.args";
 
+  // MapReduce config for specifying additional namenodes for delegation tokens
+  public static final String MAPREDUCE_JOB_OTHER_NAMENODES = "mapreduce.job.hdfs-servers";
+
+  // Azkaban property for listing additional namenodes for delegation tokens
+  private static final String OTHER_NAMENODES_PROPERTY = "other_namenodes";
+
   /**
    * Invalidates a Hadoop authentication token file
    * 
@@ -138,6 +144,24 @@ public class HadoopJobUtils {
 
     return hadoopSecurityManager;
 
+  }
+
+  /**
+   * Takes the list of other Namenodes from which to fetch delegation tokens,
+   * the {@link #OTHER_NAMENODES_PROPERTY} property, from Props and inserts it
+   * back with the addition of the the potentially JobType-specific Namenode URIs
+   * from additionalNamenodes. Modifies props in-place.
+   * @param props Props to add the new Namenode URIs to.
+   * @param additionalNamenodes Comma-separated list of Namenode URIs from which to fetch
+   *                            delegation tokens.
+   */
+  public static void addAdditionalNamenodesToProps(Props props, String additionalNamenodes) {
+    String otherNamenodes = props.get(OTHER_NAMENODES_PROPERTY);
+    if (otherNamenodes != null && otherNamenodes.length() > 0) {
+      props.put(OTHER_NAMENODES_PROPERTY, otherNamenodes + "," + additionalNamenodes);
+    } else {
+      props.put(OTHER_NAMENODES_PROPERTY, additionalNamenodes);
+    }
   }
 
   /**

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopPigJob.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopPigJob.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
 import org.apache.pig.PigRunner;
@@ -113,11 +112,7 @@ public class HadoopPigJob extends JavaProcessJob {
       Props props = new Props();
       props.putAll(getJobProps());
       props.putAll(getSysProps());
-      String additionalNamenodes =
-          (new Configuration()).get(HadoopJobUtils.MAPREDUCE_JOB_OTHER_NAMENODES);
-      if (additionalNamenodes != null && additionalNamenodes.length() > 0) {
-        HadoopJobUtils.addAdditionalNamenodesToProps(props, additionalNamenodes);
-      }
+      HadoopJobUtils.addAdditionalNamenodesToPropsFromMRJob(props, getLog());
       tokenFile =
           HadoopJobUtils
               .getHadoopTokens(hadoopSecurityManager, props, getLog());

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopPigJob.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopPigJob.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
 import org.apache.pig.PigRunner;
@@ -112,6 +113,11 @@ public class HadoopPigJob extends JavaProcessJob {
       Props props = new Props();
       props.putAll(getJobProps());
       props.putAll(getSysProps());
+      String additionalNamenodes =
+          (new Configuration()).get(HadoopJobUtils.MAPREDUCE_JOB_OTHER_NAMENODES);
+      if (additionalNamenodes != null && additionalNamenodes.length() > 0) {
+        HadoopJobUtils.addAdditionalNamenodesToProps(props, additionalNamenodes);
+      }
       tokenFile =
           HadoopJobUtils
               .getHadoopTokens(hadoopSecurityManager, props, getLog());

--- a/plugins/jobtype/test/azkaban/jobtype/TestHadoopJobUtilsAdditionalNamenodes.java
+++ b/plugins/jobtype/test/azkaban/jobtype/TestHadoopJobUtilsAdditionalNamenodes.java
@@ -1,0 +1,23 @@
+package azkaban.jobtype;
+
+import azkaban.utils.Props;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class TestHadoopJobUtilsAdditionalNamenodes {
+
+  @Test
+  public void testAdditionalNamenodes() {
+    Props testProps = new Props();
+    HadoopJobUtils.addAdditionalNamenodesToProps(testProps, "hdfs://testNN:9000");
+    Assert.assertEquals("hdfs://testNN:9000", testProps.get("other_namenodes"));
+
+    testProps = new Props();
+    testProps.put("other_namenodes", "hdfs://testNN1:9000,hdfs://testNN2:9000");
+    HadoopJobUtils.addAdditionalNamenodesToProps(testProps, "hdfs://testNN:9000");
+    Assert.assertEquals("hdfs://testNN1:9000,hdfs://testNN2:9000,hdfs://testNN:9000",
+        testProps.get("other_namenodes"));
+  }
+
+}

--- a/plugins/jobtype/test/azkaban/jobtype/TestHadoopSparkJob.java
+++ b/plugins/jobtype/test/azkaban/jobtype/TestHadoopSparkJob.java
@@ -142,4 +142,31 @@ public class TestHadoopSparkJob {
     String sparkConfPath = SPARK_BASE_DIR + "/" + SPARK_210_HOME + "/" + SPARK_HOME_CONF;
     Assert.assertEquals(sparkHomeConfPath[1], sparkConfPath);
   }
+
+  @Test
+  public void testSparkLoadsAdditionalNamenodes() throws Exception {
+    File source = new File("test_resource/additional-namenodes-spark-defaults.conf");
+    File target = new File(SPARK_BASE_DIR + "/" + SPARK_163_HOME + "/" +
+        SPARK_HOME_CONF + "/" + SPARK_DEFAULT_FILE_NAME);
+    Files.copy(source, target);
+
+    Props jobProps = new Props();
+    jobProps.put(SparkJobArg.SPARK_VERSION.azPropName, "1.6.3");
+
+    Props sysProps = new Props();
+    sysProps.put("spark.home", SPARK_BASE_DIR + "/" + SPARK_DEFAULT);
+    sysProps.put("spark.1.6.3.home", SPARK_BASE_DIR + "/" + SPARK_163_HOME);
+
+    HadoopSparkJob sparkJob = new HadoopSparkJob("azkaban_job_1", sysProps, jobProps, logger);
+
+    Props testProps = new Props();
+    sparkJob.addAdditionalNamenodesFromConf(testProps);
+    Assert.assertEquals("hdfs://testNN:9000", testProps.get("other_namenodes"));
+
+    testProps = new Props();
+    testProps.put("other_namenodes", "hdfs://testNN1:9000,hdfs://testNN2:9000");
+    sparkJob.addAdditionalNamenodesFromConf(testProps);
+    Assert.assertEquals("hdfs://testNN1:9000,hdfs://testNN2:9000,hdfs://testNN:9000",
+        testProps.get("other_namenodes"));
+  }
 }

--- a/test_resource/additional-namenodes-spark-defaults.conf
+++ b/test_resource/additional-namenodes-spark-defaults.conf
@@ -1,0 +1,1 @@
+spark.yarn.access.namenodes = hdfs://testNN:9000


### PR DESCRIPTION
Modify the Hadoop(Spark,Hive,Pig,Java)Job types to respect the MapReduce- and Spark-level configurations for additional namenodes from which to fetch delegation tokens, in addition to the Azkaban-level other_namenodes configuration. MapReduce and Spark both have configurations for specifying namenodes from which additional delegation tokens should be fetched before submitting a job (`mapreduce.job.hdfs-servers` and `spark.yarn.access.namenodes`, respectively) but previously Azkaban ignored these, using it's own `other_namenodes` property. Azkaban should additionally respect these framework-level configurations.