### PR TITLE
adding two files to gitignore lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ azkaban-jobtype-*.jar
 azkaban-pigvisualizer-*.jar
 dist/
 out/
+node_modules/
+test_resource/spark-defaults.conf
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ jdk:
 - oraclejdk8
 install:
  - time npm install -g less dustjs-linkedin
+ - sudo apt-get install ant-optional
 script: ant


### PR DESCRIPTION
* Adding two build generated files to gitignore.
* Ant build doesn't work in Travis due to missing ant-junit. Therefore, we install it before we do ant.