### PR TITLE
Added autofocus and enter button support to HDFS proxy user modal

### DIFF
--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-proxy-js.vm
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-proxy-js.vm
@@ -39,7 +39,7 @@ $(function() {
   });
 
   $('#proxyname').keyup(function(event) {
-    if (event.which == 13) {
+    if (event.key == "Enter") {
       $('#submitChangeUserBtn').click();
     }
   });

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-proxy-js.vm
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-proxy-js.vm
@@ -36,5 +36,11 @@ $(function() {
     };
     $.post("", requestData, successHandler);
   });
+
+  $('#proxyname').keyup(function(event) {
+    if (event.which == 13) {
+      $('#submitChangeUserBtn').click();
+    }
+  });
 });
 </script>

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-proxy-js.vm
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-proxy-js.vm
@@ -18,6 +18,7 @@
 $(function() {
   $('#changeUserBtn').click( function() {
     $('#messageDialog').modal();
+    $('#proxyname').focus();
   });
 
   $('#submitChangeUserBtn').click( function() {


### PR DESCRIPTION
This JavaScript tweak gives focus to the text input after clicking on the "Change User" button in the HDFS Browser, so the user doesn't have to click in the box before typing.

Additionally, while the text input is focused, this change gives the Enter key the same behavior as clicking the submit button, so the user can simply type the proxy user name and press enter rather than having to click on the submit button.

Testing Done: Pasted the script into the Javascript console (Firefox and Chrome) while on the HDFS browser page and tried switching proxy user to verify the changes.