### PR TITLE
Change hadoop workflow key to bypass mapreduce workflow key

### DIFF
--- a/plugins/jobtype/src/azkaban/jobtype/HadoopConfigurationInjector.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopConfigurationInjector.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.log4j.Logger;
 
 
@@ -50,6 +49,7 @@ public class HadoopConfigurationInjector {
   public static final String INJECT_PREFIX = "hadoop-inject.";
 
   public static final String WORKFLOW_ID_SEPERATOR = "$";
+  private static final String WORKFLOW_ID_CONFIG = "yarn.workflow.id";
   /*
    * To be called by the forked process to load the generated links and Hadoop
    * configuration properties to automatically inject.
@@ -145,7 +145,7 @@ public class HadoopConfigurationInjector {
     for(String propertyName : propsToInject) {
       addHadoopProperty(props, propertyName);
     }
-    addHadoopWorkflowProperty(props, MRJobConfig.WORKFLOW_ID);
+    addHadoopWorkflowProperty(props, WORKFLOW_ID_CONFIG);
   }
 
   /**


### PR DESCRIPTION
Frameworks such as Pig and Hive override the MRJobConfig.WORKFLOW_ID property, so we lose the azkaban project/flow information in the hadoop configuration.

This was tested locally. The azkaban metadata is correctly retrieved.