### PR TITLE
Temporarily resolve Azkaban common classpath in all job type

### DIFF
--- a/plugins/jobtype/src/azkaban/jobtype/HadoopHiveJob.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopHiveJob.java
@@ -98,7 +98,7 @@ public class HadoopHiveJob extends JavaProcessJob {
     }
 
     try {
-      super.run();  
+      super.run();
     } catch (Throwable t) {
       t.printStackTrace();
       getLog().error("caught error running the job");
@@ -111,7 +111,7 @@ public class HadoopHiveJob extends JavaProcessJob {
         }
       }
     }
-  } 
+  }
 
   @Override
   protected String getJavaClass() {
@@ -204,7 +204,11 @@ public class HadoopHiveJob extends JavaProcessJob {
 
     List<String> classPath = super.getClassPaths();
 
+    // To add az-core jar classpath
     classPath.add(getSourcePathFromClass(Props.class));
+
+    // To add az-common jar classpath
+    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
     classPath.add(getSourcePathFromClass(HadoopSecureHiveWrapper.class));
     classPath.add(getSourcePathFromClass(HadoopSecurityManager.class));
 
@@ -271,7 +275,7 @@ public class HadoopHiveJob extends JavaProcessJob {
           .getPath();
     }
   }
-  
+
   /**
    * This cancel method, in addition to the default canceling behavior, also kills the MR jobs launched by Hive
    * on Hadoop

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopJavaJob.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopJavaJob.java
@@ -122,7 +122,17 @@ public class HadoopJavaJob extends JavaProcessJob {
     }
 
     classPath.add(getSourcePathFromClass(HadoopJavaJobRunnerMain.class));
+
+    /**
+     * Todo kunkun-tang: The legacy code uses a quite outdated method to resolve
+     * Azkaban dependencies, and should be replaced later.
+     */
+
+    // To add az-core jar classpath
     classPath.add(getSourcePathFromClass(Props.class));
+
+    // To add az-common jar classpath
+    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
     classPath.add(getSourcePathFromClass(HadoopSecurityManager.class));
 
     classPath.add(HadoopConfigurationInjector.getPath(getJobProps(),

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopPigJob.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopPigJob.java
@@ -237,7 +237,11 @@ public class HadoopPigJob extends JavaProcessJob {
 
     List<String> classPath = super.getClassPaths();
 
+    // To add az-core jar classpath
     classPath.add(getSourcePathFromClass(Props.class));
+
+    // To add az-common jar classpath
+    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
     classPath.add(getSourcePathFromClass(HadoopSecurePigWrapper.class));
     classPath.add(getSourcePathFromClass(HadoopSecurityManager.class));
 

--- a/plugins/jobtype/src/azkaban/jobtype/HadoopSparkJob.java
+++ b/plugins/jobtype/src/azkaban/jobtype/HadoopSparkJob.java
@@ -480,7 +480,11 @@ public class HadoopSparkJob extends JavaProcessJob {
     String pluginDir = getSysProps().get("plugin.dir");
     List<String> classPath = super.getClassPaths();
 
+    // To add az-core jar classpath
     classPath.add(getSourcePathFromClass(Props.class));
+
+    // To add az-common jar classpath
+    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
     classPath.add(getSourcePathFromClass(HadoopSecureHiveWrapper.class));
     classPath.add(getSourcePathFromClass(HadoopSecurityManager.class));
 

--- a/plugins/jobtype/src/azkaban/jobtype/JavaJob.java
+++ b/plugins/jobtype/src/azkaban/jobtype/JavaJob.java
@@ -47,7 +47,7 @@ public class JavaJob extends JavaProcessJob {
 
   public JavaJob(String jobid, Props sysProps, Props jobProps, Logger log) {
     super(jobid, sysProps, new Props(sysProps, jobProps), log);
-    
+
     getJobProps().put(CommonJobProperties.JOB_ID, jobid);
   }
 
@@ -68,7 +68,11 @@ public class JavaJob extends JavaProcessJob {
     List<String> classPath = super.getClassPaths();
 
     classPath.add(getSourcePathFromClass(JavaJobRunnerMain.class));
+    // To add az-core jar classpath
     classPath.add(getSourcePathFromClass(Props.class));
+
+    // To add az-common jar classpath
+    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
     classPath.add(getSourcePathFromClass(SecurityUtils.class));
 
     classPath.add(HadoopConfigurationInjector.getPath(getJobProps(),


### PR DESCRIPTION
The merged [pull request](https://github.com/azkaban/azkaban/pull/1463) created a new az-core module, which should be the baseline foundation class for all other az modules. It caused a bug in AZ production cluster:
>Exception in thread "main" java.lang.NoClassDefFoundError: azkaban/jobExecutor/AbstractJob
    at java.lang.ClassLoader.defineClass1(Native Method)
    at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
    at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
    at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
    at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357)

The issue is that launched job doesn't specify `azkaban-common` classpath. The root cause comes from the old legacy codebase in `Azkaban-plugins`. Originally every jobtype tries to locate which jar includes class `Props` and include that jar as part of the classpath. However, the mentioned pull request broke it since `Props` is moved to `az-core` module now. So we locate another class in `Azkaban-common` and have the jar wrapping the class.

The solution is just temporary, and we should wholely refactor these class at some point in future.