### PR TITLE
Disable data contents in Reportal Success Email

### DIFF
--- a/plugins/reportal/src/azkaban/viewer/reportal/ReportalMailCreator.java
+++ b/plugins/reportal/src/azkaban/viewer/reportal/ReportalMailCreator.java
@@ -99,7 +99,7 @@ public class ReportalMailCreator implements MailCreator {
     Set<String> emailList = new HashSet<String>(option.getSuccessEmails());
 
     return createEmail(flow, emailList, message, "Success", azkabanName,
-        scheme, clientHostname, clientPortNumber, true);
+        scheme, clientHostname, clientPortNumber, false);
   }
 
   private boolean createEmail(ExecutableFlow flow, Set<String> emailList,


### PR DESCRIPTION
To protect data privacy, we propose to disable data/file contents in the Reportal success Email. Users are still able to see and click the data links, displayed in the emails.

Tested in reportal server.