### PR TITLE
Introduce HTML viewer to display html file on azkaban

### DIFF
--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/ContentType.java
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/ContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 LinkedIn Corp.
+ * Copyright 2018 LinkedIn Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/ContentType.java
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/ContentType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.viewer.hdfs;
+
+public enum ContentType {
+  TEXT,
+  HTML
+}

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HdfsBrowserServlet.java
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HdfsBrowserServlet.java
@@ -105,6 +105,7 @@ public class HdfsBrowserServlet extends LoginAbstractAzkabanServlet {
 
     defaultViewer = new TextFileViewer();
 
+    viewers.add(new HtmlFileViewer());
     viewers.add(new ORCFileViewer());
     viewers.add(new AvroFileViewer());
     viewers.add(new ParquetFileViewer());
@@ -380,6 +381,7 @@ public class HdfsBrowserServlet extends LoginAbstractAzkabanServlet {
           break;
         }
       }
+      page.add("contentType", viewers.get(viewerId).getContentType().name());
       page.add("viewerId", viewerId);
       page.add("hasSchema", hasSchema);
 

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HdfsFileViewer.java
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HdfsFileViewer.java
@@ -39,4 +39,8 @@ public abstract class HdfsFileViewer {
   public String getSchema(FileSystem fs, Path path) {
     return null;
   }
+
+  public ContentType getContentType() {
+    return ContentType.TEXT;
+  }
 }

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HtmlFileViewer.java
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HtmlFileViewer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 LinkedIn Corp.
+ * Copyright 2018 LinkedIn Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HtmlFileViewer.java
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HtmlFileViewer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2012 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.viewer.hdfs;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.HashSet;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.AccessControlException;
+import org.apache.log4j.Logger;
+
+public class HtmlFileViewer extends HdfsFileViewer {
+
+  private static Logger logger = Logger.getLogger(HtmlFileViewer.class);
+  private Set<String> acceptedSuffix = new HashSet<>();
+
+  // only display the first 25M chars. it is used to prevent
+  // showing/downloading gb of data
+  private static final int BUFFER_LIMIT = 25000000;
+  private static final String VIEWER_NAME = "Html";
+
+  public HtmlFileViewer() {
+    acceptedSuffix.add(".htm");
+    acceptedSuffix.add(".html");
+  }
+
+  @Override
+  public String getName() {
+    return VIEWER_NAME;
+  }
+
+
+  @Override
+  public Set<Capability> getCapabilities(FileSystem fs, Path path)
+      throws AccessControlException {
+    String fileName = path.getName();
+    int pos = fileName.lastIndexOf('.');
+    if (pos < 0) {
+      return EnumSet.noneOf(Capability.class);
+    }
+
+    String suffix = fileName.substring(pos).toLowerCase();
+    if (acceptedSuffix.contains(suffix)) {
+      return EnumSet.of(Capability.READ);
+    } else {
+      return EnumSet.noneOf(Capability.class);
+    }
+  }
+
+  public void displayFile(FileSystem fs, Path path, OutputStream outputStream,
+      int startLine, int endLine) throws IOException {
+
+    if (logger.isDebugEnabled())
+      logger.debug("read in uncompressed html file");
+
+    TextFileViewer.displayFileContent(fs, path, outputStream, startLine, endLine, BUFFER_LIMIT);
+  }
+
+  public ContentType getContentType() {
+    return ContentType.HTML;
+  }
+}

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/TextFileViewer.java
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/TextFileViewer.java
@@ -36,6 +36,9 @@ public class TextFileViewer extends HdfsFileViewer {
   private static Logger logger = Logger.getLogger(TextFileViewer.class);
   private HashSet<String> acceptedSuffix = new HashSet<String>();
 
+  // only display the first 1M chars. it is used to prevent
+  // showing/downloading gb of data
+  private static final int BUFFER_LIMIT = 1000000;
   private static final String VIEWER_NAME = "Text";
 
   public TextFileViewer() {
@@ -65,6 +68,12 @@ public class TextFileViewer extends HdfsFileViewer {
     if (logger.isDebugEnabled())
       logger.debug("read in uncompressed text file");
 
+    displayFileContent(fs, path, outputStream, startLine, endLine, BUFFER_LIMIT);
+  }
+
+  static void displayFileContent(FileSystem fs, Path path, OutputStream outputStream,
+      int startLine, int endLine, int bufferLimit) throws IOException {
+
     InputStream inputStream = null;
     BufferedReader reader = null;
     try {
@@ -73,10 +82,6 @@ public class TextFileViewer extends HdfsFileViewer {
       PrintWriter output = new PrintWriter(outputStream);
       for (int i = 1; i < startLine; i++)
         reader.readLine();
-
-      // only display the first 1M chars. it is used to prevent
-      // showing/downloading gb of data
-      final int bufferLimit = 1000000;
 
       int bufferSize = 0;
       for (int i = startLine; i < endLine; i++) {

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file-js.vm
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file-js.vm
@@ -128,7 +128,13 @@ azkaban.HdfsFileView = Backbone.View.extend({
     }
 
     $('#file-contents-loading').hide();
-    $('#file-contents').show().text(file);
+
+    var fileContents = $('#file-contents');
+    if (fileContents.is('div')) {
+      fileContents.show().html(file);
+    } else {
+      fileContents.show().text(file);
+    }
     this.rendered = true;
   }
 });

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file-js.vm
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file-js.vm
@@ -130,7 +130,7 @@ azkaban.HdfsFileView = Backbone.View.extend({
     $('#file-contents-loading').hide();
 
     var fileContents = $('#file-contents');
-    if (fileContents.is('div')) {
+    if (contentType == "HTML") {
       fileContents.show().html(file);
     } else {
       fileContents.show().text(file);

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file.vm
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file.vm
@@ -127,7 +127,12 @@
                   <span class="sr-only">Loading...</span>
                 </div>
               </div>
+
+    #if ($contentType == "HTML")
+              <div id="file-contents"></div>
+    #else
               <pre id="file-contents"></pre>
+    #end
             </div>
 
     #if ($hasSchema)

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file.vm
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file.vm
@@ -30,6 +30,7 @@
       var path = "${path}";
       var hasSchema = ${hasSchema};
       var viewerId = ${viewerId};
+      var contentType = "${contentType}";
     </script>
 #if ($allowproxy)
   #parse ("azkaban/viewer/hdfs/velocity/hdfs-proxy-js.vm")

--- a/plugins/hdfsviewer/unit/azkaban/viewer/hdfs/HtmlFileViewerTest.java
+++ b/plugins/hdfsviewer/unit/azkaban/viewer/hdfs/HtmlFileViewerTest.java
@@ -1,0 +1,87 @@
+package azkaban.viewer.hdfs;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.AccessControlException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * <pre>
+ * Test cases for HtmlFileViewer
+ *
+ * Validate accepted capabilities for the viewer and ensures that it
+ * generates the correct content and content type.
+ * </pre>
+ */
+public class HtmlFileViewerTest {
+    private static final String EMPTY_HTM = "TestHtmEmptyFile.htm";
+    private static final String VALID_HTML = "TestHtmlFile.html";
+    FileSystem fs;
+
+    HtmlFileViewer viewer;
+
+    @Before
+    public void setUp() throws IOException {
+        fs = new LocalFileSystem();
+        fs.initialize(fs.getWorkingDirectory().toUri(), new Configuration());
+        viewer = new HtmlFileViewer();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        fs.close();
+    }
+
+    @Test
+    public void testCapabilities() throws AccessControlException {
+        Set<Capability> capabilities = viewer.getCapabilities(fs, getResourcePath(EMPTY_HTM));
+        // READ should be the the one and only capability
+        assertTrue(capabilities.contains(Capability.READ));
+        assertEquals(capabilities.size(), 1);
+
+        capabilities = viewer.getCapabilities(fs, getResourcePath(VALID_HTML));
+        // READ should be the the one and only capability
+        assertTrue(capabilities.contains(Capability.READ));
+        assertEquals(capabilities.size(), 1);
+    }
+
+    @Test
+    public void testContentType() {
+        assertEquals(ContentType.HTML, viewer.getContentType());
+    }
+
+    @Test
+    public void testEmptyFile() throws IOException {
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        viewer.displayFile(fs, getResourcePath(EMPTY_HTM), outStream, 1, 2);
+        String output = outStream.toString();
+        assertTrue(output.isEmpty());
+    }
+
+    @Test
+    public void testValidHtmlFile() throws IOException {
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        viewer.displayFile(fs, getResourcePath(VALID_HTML), outStream, 1, 2);
+        String output = new String(outStream.toByteArray());
+        assertEquals(output, "<p>file content</p>\n");
+    }
+
+    /* Get Path to a file from resource dir */
+    private Path getResourcePath(String filename) {
+        URL url =
+            Thread.currentThread().getContextClassLoader()
+                .getResource("resources/" + filename);
+        return new Path(url.getPath());
+    }
+}

--- a/plugins/hdfsviewer/unit/resources/TestHtmlFile.html
+++ b/plugins/hdfsviewer/unit/resources/TestHtmlFile.html
@@ -1,0 +1,1 @@
+<p>file content</p>


### PR DESCRIPTION
Currently html files are treated as plain text on azkaban, for super simple html files, that works fine since they are still readable. For complicated and large html files, this will be unreadable. The new html viewer allows user to open up html files and view it like an actual html file. This viewer is used to display files with ".htm" or ".html" extension.