### PR TITLE
Add additional documentation for HtmlViewer plugin

### DIFF
--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HtmlFileViewer.java
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HtmlFileViewer.java
@@ -12,6 +12,21 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
+ *
+ *
+ * THIS IS AN EXPERIMENTAL FEATURE, USE WITH CAUTION.
+ *
+ * This viewer is aimed to support the rendering of very basic html files.
+ * The content of a html file will be rendered inside an iframe on azkaban
+ * web page to protect from possible malicious javascript code. It does not
+ * support rendering local image files (e.g. image stored on hdfs), but it
+ * does support showing images stored on remote network locations.
+ *
+ * In fact, not just images, but any data that is stored on HDFS are not
+ * accessible from the html page, for example, css and js files. Everything
+ * must either be self contained or referenced with internet location.
+ * (e.g. jquery script hosted on google.com can be fetched, but jquery script
+ * stored on local hdfs cannot)
  */
 
 package azkaban.viewer.hdfs;

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HtmlFileViewer.java
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HtmlFileViewer.java
@@ -86,7 +86,9 @@ public class HtmlFileViewer extends HdfsFileViewer {
     if (logger.isDebugEnabled())
       logger.debug("read in uncompressed html file");
 
-    TextFileViewer.displayFileContent(fs, path, outputStream, startLine, endLine, BUFFER_LIMIT);
+    // BUFFER_LIMIT is the only thing we care about, line limit is redundant and actually not
+    // very useful for html files. Thus using Integer.MAX_VALUE to effectively remove the endLine limit.
+    TextFileViewer.displayFileContent(fs, path, outputStream, startLine, Integer.MAX_VALUE, BUFFER_LIMIT);
   }
 
   public ContentType getContentType() {

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/TextFileViewer.java
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/TextFileViewer.java
@@ -89,7 +89,7 @@ public class TextFileViewer extends HdfsFileViewer {
         if (line == null)
           break;
 
-        // bread if reach the buffer limit
+        // break if reach the buffer limit
         bufferSize += line.length();
         if (bufferSize >= bufferLimit)
           break;

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file-js.vm
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file-js.vm
@@ -130,15 +130,23 @@ azkaban.HdfsFileView = Backbone.View.extend({
     $('#file-contents-loading').hide();
 
     if (contentType == "HTML") {
-      // write to iframe
-      var doc = document.getElementById('file-contents-iframe').contentWindow.document;
+      // Write content to iframe. We can't just set the html source content as
+      // inner html of the iframe. The iframe hosts a completely separate dom
+      // structure than the current html, thus setting the innher HTML will not
+      // work. The only way to store html inside iframe is by either writing
+      // the content directly into it or set the content in srcdoc attribute.
+      // Since either way is fine, will go with write method since it looks
+      // nicer when you inspect the html structure.
+      var iframe = document.getElementById('file-contents-iframe');
+      var doc = iframe.contentWindow.document;
       doc.open();
       doc.write(file);
       doc.close();
       // adjust iframe size
-      var iframe = document.getElementById('file-contents-iframe');
       iframe.width  = iframe.contentWindow.document.body.scrollWidth;
       iframe.height = iframe.contentWindow.document.body.scrollHeight;
+      // show iframe (initially it's hidden)
+      iframe.style.display = "inline";
     } else {
       $('#file-contents').show().text(file);
     }

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file-js.vm
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file-js.vm
@@ -130,6 +130,9 @@ azkaban.HdfsFileView = Backbone.View.extend({
     $('#file-contents-loading').hide();
 
     if (contentType == "HTML") {
+      var iframe = document.getElementById('file-contents-iframe');
+      // show iframe (initially it's hidden)
+      iframe.style.display = "inline";
       // Write content to iframe. We can't just set the html source content as
       // inner html of the iframe. The iframe hosts a completely separate dom
       // structure than the current html, thus setting the innher HTML will not
@@ -137,7 +140,6 @@ azkaban.HdfsFileView = Backbone.View.extend({
       // the content directly into it or set the content in srcdoc attribute.
       // Since either way is fine, will go with write method since it looks
       // nicer when you inspect the html structure.
-      var iframe = document.getElementById('file-contents-iframe');
       var doc = iframe.contentWindow.document;
       doc.open();
       doc.write(file);

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file-js.vm
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file-js.vm
@@ -135,7 +135,7 @@ azkaban.HdfsFileView = Backbone.View.extend({
       iframe.style.display = "inline";
       // Write content to iframe. We can't just set the html source content as
       // inner html of the iframe. The iframe hosts a completely separate dom
-      // structure than the current html, thus setting the innher HTML will not
+      // structure than the current html, thus setting the inner HTML will not
       // work. The only way to store html inside iframe is by either writing
       // the content directly into it or set the content in srcdoc attribute.
       // Since either way is fine, will go with write method since it looks

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file-js.vm
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file-js.vm
@@ -147,8 +147,6 @@ azkaban.HdfsFileView = Backbone.View.extend({
       // adjust iframe size
       iframe.width  = iframe.contentWindow.document.body.scrollWidth;
       iframe.height = iframe.contentWindow.document.body.scrollHeight;
-      // show iframe (initially it's hidden)
-      iframe.style.display = "inline";
     } else {
       $('#file-contents').show().text(file);
     }

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file.vm
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/velocity/hdfs-file.vm
@@ -130,7 +130,7 @@
               </div>
 
     #if ($contentType == "HTML")
-              <iframe id="file-contents-iframe" src="about:blank" style="overflow:scroll" sandbox="allow-same-origin"></iframe>
+              <iframe id="file-contents-iframe" style="display:none;overflow:scroll" sandbox="allow-same-origin"></iframe>
     #else
               <pre id="file-contents"></pre>
     #end


### PR DESCRIPTION
In HtmlFileViewer.java, added documentation to describe the intended usage and support for this plugin, alerted users that this is simply an experimental feature, not intended for all types of html files.

In hdfs-file-js.vm template file, added documentation to describe why iframe content has to be injected in that particular way.