### PR TITLE
fix teradata jar missing issue

### DIFF
--- a/plugins/jobtype/src/azkaban/jobtype/connectors/teradata/TeradataJob.java
+++ b/plugins/jobtype/src/azkaban/jobtype/connectors/teradata/TeradataJob.java
@@ -62,6 +62,10 @@ public abstract class TeradataJob extends HadoopJavaJob {
   }
 
 
+  // Copy the method from HadoopJavaJob class. Since TeradataJob will eventually move to the main
+  // AZ repo, we'd keep private method in HadoopJava, and will deprecate this method during the
+  // move.
+  // TODO kunkun-tang: Remove the method when moving teradata job to the main AZ repo.
   private static String getSourcePathFromClass(Class<?> containedClass) {
     File file =
         new File(containedClass.getProtectionDomain().getCodeSource()


### PR DESCRIPTION
Since we separated Teradata classes with other jobtype classes in https://github.com/azkaban/azkaban/pull/1717, it resulted in two individual jars: jobtype jar and Teradata Jar. 
Today Azkaban adds original jobtype dependency classpath by specifying the exact class name, retrieving which jar includes this class, and appending the jar into Job JVM starting command. For example,
https://github.com/azkaban/azkaban/blob/7cd51237ad9e9f1994931cbe64f6dc1a640c0ece/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJob.java#L132

Because we separated the teradata and jobtype jar, we need to add teradata jar to classpath explicitly.
