### PR TITLE
Configurable access error message

### DIFF
--- a/plugins/hdfsviewer/conf/plugin.properties
+++ b/plugins/hdfsviewer/conf/plugin.properties
@@ -10,3 +10,4 @@ proxy.user=azkaban
 proxy.keytab.location=
 allow.group.proxy=false
 file.max.lines=1000
+#Need a filed of "configurable.error.access.message" specifying the error message we want user to get when they don't have a permission

--- a/plugins/hdfsviewer/conf/plugin.properties
+++ b/plugins/hdfsviewer/conf/plugin.properties
@@ -10,4 +10,5 @@ proxy.user=azkaban
 proxy.keytab.location=
 allow.group.proxy=false
 file.max.lines=1000
-#Need a filed of "configurable.error.access.message" specifying the error message we want user to get when they don't have a permission
+#viewer.access_denied_message=The folder you are trying to access is protected.
+#Need a filed of "viewer.access_denied_message" specifying the error message we want user to get when they don't have a permission

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HdfsBrowserServlet.java
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HdfsBrowserServlet.java
@@ -337,7 +337,8 @@ public class HdfsBrowserServlet extends LoginAbstractAzkabanServlet {
       }
       page.add("dirsize", size);
     } catch (AccessControlException e) {
-      page.add("error_message", "Permission denied: " + e.getMessage());
+      String error_message = props.getString("configurable.error.access.message");
+      page.add("error_message", "Permission denied: " + error_message);
       page.add("no_fs", "true");
     } catch (IOException e) {
       page.add("error_message", "Error: " + e.getMessage());

--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HdfsBrowserServlet.java
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HdfsBrowserServlet.java
@@ -54,7 +54,9 @@ public class HdfsBrowserServlet extends LoginAbstractAzkabanServlet {
       "hdfs.browser.proxy.user";
   private static final String HADOOP_SECURITY_MANAGER_CLASS_PARAM =
       "hadoop.security.manager.class";
-
+  private static final String HDFSVIEWER_ACCESS_DENIED_MESSAGE = 
+      "viewer.access_denied_message";
+      
   private static final int DEFAULT_FILE_MAX_LINES = 1000;
 
   private int fileMaxLines;
@@ -337,7 +339,7 @@ public class HdfsBrowserServlet extends LoginAbstractAzkabanServlet {
       }
       page.add("dirsize", size);
     } catch (AccessControlException e) {
-      String error_message = props.getString("configurable.error.access.message");
+      String error_message = props.getString(HDFSVIEWER_ACCESS_DENIED_MESSAGE);
       page.add("error_message", "Permission denied: " + error_message);
       page.add("no_fs", "true");
     } catch (IOException e) {


### PR DESCRIPTION
What we had for error message was hard coded static string. But now, we created a configurable error message.