### PR TITLE
remove goHomeDir action

### DIFF
--- a/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HdfsBrowserServlet.java
+++ b/plugins/hdfsviewer/src/azkaban/viewer/hdfs/HdfsBrowserServlet.java
@@ -174,9 +174,7 @@ public class HdfsBrowserServlet extends LoginAbstractAzkabanServlet {
       throws ServletException {
     User user = session.getUser();
     String username = user.getUserId();
-    if (hasParam(req, "action") && getParam(req, "action").equals("goHomeDir")) {
-      username = getParam(req, "proxyname");
-    } else if (allowGroupProxy) {
+    if (allowGroupProxy) {
       String proxyName =
           (String) session.getSessionData(PROXY_USER_SESSION_KEY);
       if (proxyName != null) {


### PR DESCRIPTION
The HdfsBrowserServlet allows a user to view HDFS as their own authenticated user or as any other proxy user. Looking at the validation logic, 3 branches exist for obtaining the username of the current user which the plugin proxies as:

1. Current user from session
2. Proxy user via session attribute which validates the user has permissions
3. A "proxyname" parameter when "action" is set to "goHomeDir"
The final option is implemented as follows:

plugins/hdfsviewer/src/azkaban/viewer/hdfs/HdfsBrowserServlet.java
if(hasParam(req, "action") && getParam(req, "action").equals("goHomeDir")) {
    username = getParam(req, "proxyname");
}

This means a user can "proxy" as any other valid user by simple appending "?action=goHomeDir&proxyname=$username" to the URL.

This PR removes goHomeDir action.
